### PR TITLE
fix doc generation to have top-level index

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -57,6 +57,8 @@ dependencies = ["doc"]
 
 # Build and open docs for all workspace members
 [tasks.open_docs]
+env = { "RUSTDOCFLAGS" = "--enable-index-page -Zunstable-options"}
+workspace = false
 command = "cargo"
 args = ["doc", "--no-deps", "--open"]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -34,34 +34,35 @@ args = ["test", "--examples", "--workspace"]
 # Uncomment following line to elevate warnings to errors here as well
 # env = { "RUSTDOCFLAGS" = "-Dwarnings"}
 # Try to get workspace index into docs using nightly toolchain
- env = { "RUSTDOCFLAGS" = "--enable-index-page -Zunstable-options"}
+env = { "RUSTDOCFLAGS" = "--enable-index-page -Zunstable-options"}
 command = "cargo"
-args = ["doc", "--no-deps", "--workspace"]
+args = ["doc", "--no-deps"]
 
 # Set alias so that the default dev flow points to member_task instead.
 [tasks.default]
-alias = "member_task"
+alias = "composite"
 
 ## Fancy flow is you need to run different commands
 ## at the workspace level than for each member crate
 ## This flow runs "member_flow" for each member crate
 ## and "workspace_flow" at root.
-#[tasks.composite]
-#workspace = false
-#dependencies = ["member_flow", "workspace_flow"]
+[tasks.composite]
+workspace = false
+dependencies = ["member_flow", "workspace_flow"]
 
 ## Tasks here run from root directory
-#[tasks.workspace_flow]
-#workspace = false
+[tasks.workspace_flow]
+workspace = false
+dependencies = ["doc"]
 
 # Build and open docs for all workspace members
 [tasks.open_docs]
 command = "cargo"
-args = ["doc", "--no-deps", "--workspace", "--open"]
+args = ["doc", "--no-deps", "--open"]
 
 ## Run member_task for each workspace member.
-#[tasks.member_flow]
-#run_task = { name = "member_task", fork = true }
+[tasks.member_flow]
+run_task = { name = "member_task", fork = true }
 
 # Tasks to be run in each workspace member
 [tasks.member_task]
@@ -72,6 +73,5 @@ dependencies = [
     "build",
     "test",
     "examples",
-    "doc"
 ]
 

--- a/README.md
+++ b/README.md
@@ -7,27 +7,27 @@ Currently there is a library crate, `classical_crypto`, which implements some hi
 
 # build instructions
 To build, run 
-`cargo make`.
+`cargo make` using the nightly toolchain[^1].
+
 
 If you have never used  the `cargo-make` task runner before, see [here](https://github.com/sagiegurari/cargo-make?tab=readme-ov-file#installation) for installation instructions.
 
 Note that we do not track _Cargo.lock_ in this repository, so builds are not considered reproducible.
 
+[^1]: We use nightly to create documentation that results in a top-level index file. The build should otherwise still work on the stable rust toolchain.
+
 # documentation
 
-Documentation of the workspace members is built automatically by `cargo make`. After building, you can open `fiddler/target/doc/index.html` in any browser. Alternatively, you can build and open the documentation by running
-`
-cargo make open_docs
-`, which uses the custom flags set in the top-level Makefile.toml file.
+Documentation of the workspace members is built automatically by `cargo make` _when using the nightly toolchain_. After building, you can open `fiddler/target/doc/index.html` in any browser. 
 
 Alternatively, run 
 `
 cargo make open_docs
 ` from the workspace root, which uses custom flags set in the top-level Makefile.toml file, 
-or the standard
+or, if you are not on nightly, the standard
 `
 cargo doc --open
-`, which builds and opens the documentation for the included crates as well as their dependencies.
+`, which builds and opens the documentation for the included crates as well as their dependencies. 
 
 Since this is a learning crate, it may also be helpful to document private items. To do so, pass the option `--document-private-items` to `cargo doc`.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Note that we do not track _Cargo.lock_ in this repository, so builds are not con
 
 # documentation
 
-Documentation of the workspace members is built automatically by `cargo make`. After building, you can open `fiddler/target/doc/fiddler/index.html` in any browser. Alternatively, you can build and open the documentation by running
+Documentation of the workspace members is built automatically by `cargo make`. After building, you can open `fiddler/target/doc/index.html` in any browser. Alternatively, you can build and open the documentation by running
 `
 cargo make open_docs
 `, which uses the custom flags set in the top-level Makefile.toml file.


### PR DESCRIPTION
The simplification of Makefile.toml didn't work correctly, as it resulted in no top-level index file being generated as part of the docs. This PR re-establishes the flow that created a top-level doc and updates the README to include the correct path for this doc.