### PR TITLE
Cipher trait

### DIFF
--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -29,6 +29,7 @@
 //! sequences of ring elements (i.e., plaintexts and ciphertexts, respectively).
 // (&#x2124; is Unicode for blackboard bold Z)
 
+pub use crate::shift::ShiftCipher;
 use rand::{CryptoRng, Rng};
 use std::{
     fmt,
@@ -36,7 +37,7 @@ use std::{
     str::FromStr,
 };
 
-pub mod shift;
+mod shift;
 
 /// This trait represents a deterministic cipher.
 pub trait Cipher {

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -29,7 +29,6 @@
 //! sequences of ring elements (i.e., plaintexts and ciphertexts, respectively).
 // (&#x2124; is Unicode for blackboard bold Z)
 
-pub use crate::shift::ShiftCipher;
 use rand::{CryptoRng, Rng};
 use std::{
     fmt,
@@ -37,7 +36,7 @@ use std::{
     str::FromStr,
 };
 
-mod shift;
+pub mod shift;
 
 /// This trait represents a deterministic cipher.
 pub trait Cipher {

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -287,7 +287,7 @@ pub struct Message(Vec<RingElement>);
 
 /// A ciphertext of arbitrary length.
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
-pub struct Ciphertext(Vec<RingElement>);
+struct Ciphertext(Vec<RingElement>);
 
 // TODO: refactor
 impl Message {
@@ -299,7 +299,7 @@ impl Message {
     /// // That said, humans are very quick at understanding mashed up plaintexts
     /// // without punctuation and spacing.
     /// // Computers have to check dictionaries.
-    /// # use classical_crypto::{Ciphertext, Key, Message};
+    /// # use classical_crypto::{Key, Message};
     /// # use rand::thread_rng;
     /// let msg = Message::new("thisisanawkwardapichoice").expect("This example is hardcoded; it should work!");
     ///

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -46,8 +46,8 @@ pub trait Cipher {
     /// The ciphertext space of the cipher.
     type Ciphertext;
 
-    /// The keyspace of the cipher.
-    type Key;
+    /// The keyspace of the cipher, which must implement the [`Key`] trait.
+    type Key: Key;
 
     // TODO: not implemented yet
     /// The error type returned by [`Cipher::encrypt`].

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -46,8 +46,8 @@ pub trait Cipher {
     /// The ciphertext space of the cipher.
     type Ciphertext;
 
-    /// The keyspace of the cipher, which must implement the [`Key`] trait.
-    type Key: Key;
+    /// The keyspace of the cipher.
+    type Key;
 
     // TODO: not implemented yet
     /// The error type returned by [`Cipher::encrypt`].
@@ -56,6 +56,9 @@ pub trait Cipher {
     // TODO: not implemented yet
     /// The error type returned by [`Cipher::decrypt`].
     type DecryptionError;
+
+    /// Pick a new key from the key space uniformly at random.
+    fn gen_key<R: Rng + CryptoRng>(rng: &mut R) -> Self::Key;
 
     // TODO: Return a Result instead
     /// The encryption function of the cipher.
@@ -70,11 +73,6 @@ pub trait Cipher {
     fn decrypt(ciphertxt: &Self::Ciphertext, key: &Self::Key) -> Self::Message;
 }
 
-/// A trait for cryptographic keys.
-pub trait Key {
-    /// Pick a new key from the key space uniformly at random.
-    fn new<R: Rng + CryptoRng>(rng: &mut R) -> Self;
-}
 /// This trait represents an encoding of the characters of an alphabet.
 trait AlphabetEncoding: Sized {
     /// The associated error type.
@@ -298,7 +296,7 @@ impl Message {
     /// // That said, humans are very quick at understanding mashed up plaintexts
     /// // without punctuation and spacing.
     /// // Computers have to check dictionaries.
-    /// # use classical_crypto::{Ciphertext, Key, Message};
+    /// # use classical_crypto::{Ciphertext, Message};
     /// # use rand::thread_rng;
     /// let msg = Message::new("thisisanawkwardapichoice").expect("This example is hardcoded; it should work!");
     ///

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -39,22 +39,22 @@ use std::{
 pub mod shift;
 
 /// This trait represents a deterministic cipher.
-pub trait Cipher {
+pub trait CipherTrait {
     /// The message space (plaintext space) of the cipher.
     type Message;
 
     /// The ciphertext space of the cipher.
     type Ciphertext;
 
-    /// The keyspace of the cipher, which must implement the [`Key`] trait.
-    type Key: Key;
+    /// The keyspace of the cipher, which must implement the [`KeyTrait`] trait.
+    type Key: KeyTrait;
 
     // TODO: not implemented yet
-    /// The error type returned by [`Cipher::encrypt`].
+    /// The error type returned by [`CipherTrait::encrypt`].
     type EncryptionError;
 
     // TODO: not implemented yet
-    /// The error type returned by [`Cipher::decrypt`].
+    /// The error type returned by [`CipherTrait::decrypt`].
     type DecryptionError;
 
     // TODO: Return a Result instead
@@ -71,7 +71,7 @@ pub trait Cipher {
 }
 
 /// A trait for cryptographic keys.
-pub trait Key {
+pub trait KeyTrait {
     /// Pick a new key from the key space uniformly at random.
     fn new<R: Rng + CryptoRng>(rng: &mut R) -> Self;
 }
@@ -300,12 +300,12 @@ impl Message {
 /// This is likely because the string violates one of the constraints
 /// for the desired value type. That is:
 ///
-/// - For [`Message`]: The string included one or more characters that are not
+/// - For messages: The string included one or more characters that are not
 ///   lowercase letters from the Latin Alphabet.
-/// - For [`Ciphertext`]: The string included one or more characters that are
-///   not letters from the Latin Alphabet. We allow for strings containing both
+/// - For ciphertexts: The string included one or more characters that are not
+///   letters from the Latin Alphabet. We allow for strings containing both
 ///   capitalized and lowercase letters when parsing as string as a ciphertext.
-/// - For [`Key`]: The string does not represent a number in the appropriate
+/// - For key values: The string does not represent a number in the appropriate
 ///   range. For the Latin Alphabet, this range is 0 to 25, inclusive.
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct EncodingError;

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -282,30 +282,15 @@ impl fmt::Display for RingElement {
 
 /// A plaintext of arbitrary length.
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
-pub struct Message(Vec<RingElement>);
+struct Message(Vec<RingElement>);
 
 /// A ciphertext of arbitrary length.
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 struct Ciphertext(Vec<RingElement>);
 
-// TODO: refactor
 impl Message {
     /// Create a new message from a string.
-    /// # Examples
-    /// ```
-    /// // Creating this example shows how awkward our API is.
-    /// // We can't use spaces, punctuation, or capital letters.
-    /// // That said, humans are very quick at understanding mashed up plaintexts
-    /// // without punctuation and spacing.
-    /// // Computers have to check dictionaries.
-    /// # use classical_crypto::{Key, Message};
-    /// # use rand::thread_rng;
-    /// let msg = Message::new("thisisanawkwardapichoice").expect("This example is hardcoded; it should work!");
-    ///
-    /// // We can also print our message as a string:
-    /// println!("Our message is {msg}");
-    /// ```
-    pub fn new(str: &str) -> Result<Message, EncodingError> {
+    fn new(str: &str) -> Result<Message, EncodingError> {
         Message::from_str(str)
     }
 }

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -46,8 +46,8 @@ pub trait Cipher {
     /// The ciphertext space of the cipher.
     type Ciphertext;
 
-    /// The keyspace of the cipher.
-    type Key;
+    /// The keyspace of the cipher, which must implement the [`Key`] trait.
+    type Key: Key;
 
     // TODO: not implemented yet
     /// The error type returned by [`Cipher::encrypt`].
@@ -56,9 +56,6 @@ pub trait Cipher {
     // TODO: not implemented yet
     /// The error type returned by [`Cipher::decrypt`].
     type DecryptionError;
-
-    /// Pick a new key from the key space uniformly at random.
-    fn gen_key<R: Rng + CryptoRng>(rng: &mut R) -> Self::Key;
 
     // TODO: Return a Result instead
     /// The encryption function of the cipher.
@@ -73,6 +70,11 @@ pub trait Cipher {
     fn decrypt(ciphertxt: &Self::Ciphertext, key: &Self::Key) -> Self::Message;
 }
 
+/// A trait for cryptographic keys.
+pub trait Key {
+    /// Pick a new key from the key space uniformly at random.
+    fn new<R: Rng + CryptoRng>(rng: &mut R) -> Self;
+}
 /// This trait represents an encoding of the characters of an alphabet.
 trait AlphabetEncoding: Sized {
     /// The associated error type.
@@ -296,7 +298,7 @@ impl Message {
     /// // That said, humans are very quick at understanding mashed up plaintexts
     /// // without punctuation and spacing.
     /// // Computers have to check dictionaries.
-    /// # use classical_crypto::{Ciphertext, Message};
+    /// # use classical_crypto::{Ciphertext, Key, Message};
     /// # use rand::thread_rng;
     /// let msg = Message::new("thisisanawkwardapichoice").expect("This example is hardcoded; it should work!");
     ///

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -11,7 +11,7 @@ use std::str::FromStr;
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Shift;
 
-// TODO: Should key be a trait too?
+
 /// A cryptographic key.
 // Crypto TODO: Keys should always contain context.
 // We *could* implement `Copy` and `Clone` here.

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -7,12 +7,11 @@ use crate::{Cipher, Ciphertext, EncodingError, Key, Message, Ring, RingElement};
 use rand::{CryptoRng, Rng};
 use std::str::FromStr;
 
-/// The Latin Shift Cipher.
+/// An implementation of the Latin Shift Cipher.
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
-pub struct Shift;
+pub struct ShiftCipher;
 
-
-/// A cryptographic key.
+/// A cryptographic key for the Latin Shift Cipher.
 // Crypto TODO: Keys should always contain context.
 // We *could* implement `Copy` and `Clone` here.
 // We do not because we want to discourage making copies of secrets.
@@ -20,7 +19,7 @@ pub struct Shift;
 #[derive(Debug, Eq, PartialEq)]
 pub struct ShiftKey(RingElement);
 
-impl Cipher for Shift {
+impl Cipher for ShiftCipher {
     type Message = Message;
     type Ciphertext = Ciphertext;
     type Key = ShiftKey;
@@ -32,12 +31,12 @@ impl Cipher for Shift {
     ///
     /// # Examples
     /// ```
-    /// # use classical_crypto::{Cipher, Key, shift::Shift};
+    /// # use classical_crypto::{Cipher, Key, ShiftCipher};
     /// # use rand::thread_rng;
     /// # let mut rng = thread_rng();
     /// # let key = Key::new(&mut rng);
-    ///  let msg = <Shift as Cipher>::Message::new("thisisanawkwardapichoice").expect("This example is hardcoded; it should work!");
-    /// let ciphertxt = Shift::encrypt(&msg, &key);
+    ///  let msg = <ShiftCipher as Cipher>::Message::new("thisisanawkwardapichoice").expect("This example is hardcoded; it should work!");
+    /// let ciphertxt = ShiftCipher::encrypt(&msg, &key);
     /// ```
     fn encrypt(msg: &Self::Message, key: &Self::Key) -> Self::Ciphertext {
         msg.0.iter().map(|&i| i + key.0).collect()
@@ -48,14 +47,14 @@ impl Cipher for Shift {
     ///
     /// # Examples
     /// ```
-    /// # use classical_crypto::{Cipher, Key, shift::Shift};
+    /// # use classical_crypto::{Cipher, Key, ShiftCipher};
     /// # use rand::thread_rng;
     /// #
     /// # let mut rng = thread_rng();
     /// # let key = Key::new(&mut rng);
-    /// # let msg = <Shift as Cipher>::Message::new("thisisanawkwardapichoice").expect("This example is hardcoded; it should work!");
-    /// # let ciphertxt = Shift::encrypt(&msg, &key);
-    /// let decrypted = Shift::decrypt(&ciphertxt, &key);
+    /// # let msg = <ShiftCipher as Cipher>::Message::new("thisisanawkwardapichoice").expect("This example is hardcoded; it should work!");
+    /// # let ciphertxt = ShiftCipher::encrypt(&msg, &key);
+    /// let decrypted = ShiftCipher::decrypt(&ciphertxt, &key);
     ///
     /// println!(
     ///    "If we decrypt using the correct key, we get our original
@@ -65,12 +64,12 @@ impl Cipher for Shift {
     /// if key != wrong_key {
     /// println!("If we decrypt using an incorrect key, we do not get
     ///  our original message back: {}",
-    /// Shift::decrypt(&ciphertxt, &wrong_key));
+    /// ShiftCipher::decrypt(&ciphertxt, &wrong_key));
     /// }
     /// ```
     ///
     /// ```
-    /// # use classical_crypto::{Cipher, Key, shift::Shift};
+    /// # use classical_crypto::{Cipher, Key, ShiftCipher};
     /// # use rand::thread_rng;
     /// #
     /// # let mut rng = thread_rng();
@@ -84,11 +83,11 @@ impl Cipher for Shift {
     /// // one sample, one ciphertext may not be enough to definitively
     /// // break the system with a brute force attack. But likely there
     /// // is other context available to validate possible plaintexts.
-    /// let small_msg = <Shift as Cipher>::Message::new("dad").expect("This example is hardcoded; it should work!");
-    /// let small_ciphertext = Shift::encrypt(&small_msg, &key);
+    /// let small_msg = <ShiftCipher as Cipher>::Message::new("dad").expect("This example is hardcoded; it should work!");
+    /// let small_ciphertext = ShiftCipher::encrypt(&small_msg, &key);
     /// // This will also decrypt the message properly with probability 1/26
     /// // which is of course a huge probability of success.
-    /// let small_decryption = Shift::decrypt(&small_ciphertext,
+    /// let small_decryption = ShiftCipher::decrypt(&small_ciphertext,
     ///  &Key::new(&mut rng));
     ///
     /// println!("Here is a small example, where we can more
@@ -107,8 +106,8 @@ impl Cipher for Shift {
 impl Key for ShiftKey {
     /// Generate a cryptographic key uniformly at random from the key space.
     ///
-    /// Note that the mathematical description of the Latin Shift Cipher, as
-    /// well as this implementation, does not disallow a key of 0, so
+    /// Note that the mathematical description of the Latin Shift Cipher,
+    /// as well as this implementation, does not disallow a key of 0, so
     /// sometimes the encryption algorithm is just the identity function.
     ///
     /// This is, after all, a cryptosystem designed for use by humans and not
@@ -119,7 +118,7 @@ impl Key for ShiftKey {
     ///
     /// # Examples
     /// ```
-    /// # use classical_crypto::{Cipher, Key, shift::Shift};
+    /// # use classical_crypto::{Cipher, Key, ShiftCipher};
     /// // Don't forget to include the `rand` crate!
     /// use rand::thread_rng;
     /// //
@@ -127,7 +126,7 @@ impl Key for ShiftKey {
     /// let mut rng = thread_rng();
     /// //
     /// // Generate a key
-    /// let key = <Shift as Cipher>::Key::new(&mut rng);
+    /// let key = <ShiftCipher as Cipher>::Key::new(&mut rng);
     /// ```
     // Note: Keys must always be chosen according to a uniform distribution on the
     // underlying key space, i.e., the ring Z/26Z for the Latin Alphabet cipher.
@@ -136,12 +135,12 @@ impl Key for ShiftKey {
     }
 }
 
-impl ShiftKey {
-    /// Export the key
+impl ShiftCipher {
+    /// Export the cryptographic key, insecurely.
     ///
     /// # Examples
     /// ```
-    /// # use classical_crypto::{Cipher, Key, shift::Shift};
+    /// # use classical_crypto::{Cipher, Key, ShiftCipher};
     /// # // Don't forget to include the `rand` crate!
     /// # use rand::thread_rng;
     /// # //
@@ -149,17 +148,17 @@ impl ShiftKey {
     /// # let mut rng = thread_rng();
     /// # //
     /// # // Generate a key
-    /// # let key = <Shift as Cipher>::Key::new(&mut rng);
+    /// # let key = <ShiftCipher as Cipher>::Key::new(&mut rng);
     /// //
     /// // We can export a key for external storage or other uses.
     /// // This method does not do anything special for secure key
     /// // handling, which is another, more complicated
     /// // and error-prone topic.
     /// // Use caution.
-    /// println!("Here is our key value: {}", key.insecure_export());
+    /// println!("Here is our key value: {}", ShiftCipher::insecure_key_export(&key));
     /// ```
-    pub fn insecure_export(&self) -> String {
-        self.0.into_inner().to_string()
+    pub fn insecure_key_export(key: &<Self as Cipher>::Key) -> String {
+        key.0.into_inner().to_string()
     }
 }
 
@@ -196,12 +195,12 @@ impl From<RingElement> for ShiftKey {
 }
 
 // TODO: Not implemented yet
-/// A custom error type that is returned from [`Shift::encrypt`].
+/// A custom error type that is returned from [`ShiftCipher::encrypt`].
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct EncryptionError;
 
 // TODO: not implemented yet
-/// A custom error type that is returned from [`Shift::decrypt`].
+/// A custom error type that is returned from [`ShiftCipher::decrypt`].
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct DecryptionError;
 
@@ -254,11 +253,11 @@ mod tests {
     fn enc_dec_basic() {
         let key0 = ShiftKey(RingElement(11));
 
-        let ciph0 = Shift::encrypt(&Message::new("wewillmeetatmidnight").unwrap(), &key0);
+        let ciph0 = ShiftCipher::encrypt(&Message::new("wewillmeetatmidnight").unwrap(), &key0);
 
         assert_eq!(ciph0, CIPH0.with(|ciph| ciph.clone())); // Ciphertext is correct
         assert_eq!(
-            Shift::decrypt(&ciph0, &key0),
+            ShiftCipher::decrypt(&ciph0, &key0),
             MSG0.with(|msg| msg.clone()) // Ciphertext decrypts correctly
         )
     }
@@ -276,14 +275,20 @@ mod tests {
 
         // If you encrypt, then decrypt with the same key used during encryption, you
         // get the same message back.
-        assert_eq!(Shift::decrypt(&Shift::encrypt(&msg1, &key1), &key1), msg1);
+        assert_eq!(
+            ShiftCipher::decrypt(&ShiftCipher::encrypt(&msg1, &key1), &key1),
+            msg1
+        );
 
         // If you encrypt, then try to decrypt with a different key than the one used
         // during encryption, you should not get the same one back. (Note this
         // test won't run if the keys collide, which they will with probability
         // 1/26, i.e., the keyspace for the Latin Shift Cipher system is *tiny*.
         if key1 != key2 {
-            assert_ne!(Shift::decrypt(&Shift::encrypt(&msg2, &key1), &key2), msg2)
+            assert_ne!(
+                ShiftCipher::decrypt(&ShiftCipher::encrypt(&msg2, &key1), &key2),
+                msg2
+            )
         }
     }
 
@@ -301,10 +306,16 @@ mod tests {
         assert_ne!(key1, key2);
 
         // Encrypted message always decrypts correctly
-        assert_eq!(Shift::decrypt(&Shift::encrypt(&msg1, &key1), &key1), msg1);
+        assert_eq!(
+            ShiftCipher::decrypt(&ShiftCipher::encrypt(&msg1, &key1), &key1),
+            msg1
+        );
         // Encrypted message won't decrypt correctly without the correct key
         // This test is OK because a manual check has been done to ensure the keys are
         // different.
-        assert_ne!(Shift::decrypt(&Shift::encrypt(&msg1, &key1), &key2), msg1)
+        assert_ne!(
+            ShiftCipher::decrypt(&ShiftCipher::encrypt(&msg1, &key1), &key2),
+            msg1
+        )
     }
 }

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -5,18 +5,10 @@
 //! space_ is &#x2124;/26&#x2124;. as well.
 use crate::{Cipher, Ciphertext as Ciphtxt, EncodingError, Key, Message, Ring, RingElement};
 use rand::{CryptoRng, Rng};
-use std::{fmt::Display, ops::Deref, str::FromStr};
+use std::{fmt::Display, str::FromStr};
 
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Ciphertext(Ciphtxt);
-
-impl Deref for Ciphertext {
-    type Target = Ciphtxt;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
 
 impl FromStr for Ciphertext {
     type Err = EncodingError;
@@ -27,7 +19,7 @@ impl FromStr for Ciphertext {
 
 impl Display for Ciphertext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Ciphtxt::fmt(self, f)
+        Ciphtxt::fmt(&self.0, f)
     }
 }
 

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -35,10 +35,9 @@ impl Cipher for Shift {
     /// # use classical_crypto::{Cipher, Key, shift::Shift};
     /// # use rand::thread_rng;
     /// # let mut rng = thread_rng();
-    /// # let key = Key::new(&mut rng); 
-    ///  let msg = <Shift as Cipher>::Message::new("thisisanawkwardapichoice").expect("This example is hardcoded; it should work!"); 
-    /// let ciphertxt = Shift::encrypt(&msg, &key); 
-    /// 
+    /// # let key = Key::new(&mut rng);
+    ///  let msg = <Shift as Cipher>::Message::new("thisisanawkwardapichoice").expect("This example is hardcoded; it should work!");
+    /// let ciphertxt = Shift::encrypt(&msg, &key);
     /// ```
     fn encrypt(msg: &Self::Message, key: &Self::Key) -> Self::Ciphertext {
         msg.0.iter().map(|&i| i + key.0).collect()

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -5,7 +5,7 @@
 //! space_ is &#x2124;/26&#x2124;. as well.
 use crate::{Cipher, Ciphertext as Ciphtxt, EncodingError, Key, Message, Ring, RingElement};
 use rand::{CryptoRng, Rng};
-use std::{ops::Deref, str::FromStr};
+use std::{fmt::Display, ops::Deref, str::FromStr};
 
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Ciphertext(Ciphtxt);
@@ -22,6 +22,12 @@ impl FromStr for Ciphertext {
     type Err = EncodingError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Ciphertext(Ciphtxt::from_str(s)?))
+    }
+}
+
+impl Display for Ciphertext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Ciphtxt::fmt(self, f)
     }
 }
 
@@ -112,7 +118,7 @@ impl Cipher for ShiftCipher {
     /// easily see the preservation of patterns:
     /// \n plaintext is {}, ciphertext is {},
     ///  and decryption under a random key gives {}",
-    /// small_msg, *small_ciphertext,
+    /// small_msg, small_ciphertext,
     /// small_decryption)
     /// ```
     fn decrypt(ciphertxt: &Self::Ciphertext, key: &Self::Key) -> Self::Message {

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -3,9 +3,27 @@
 //! &#x2124;/26&#x2124;. As the name implies, ciphertexts are shifts (computed
 //! using modular arithmetic) of the corresponding plaintexts, so the _key
 //! space_ is &#x2124;/26&#x2124;. as well.
-use crate::{Cipher, Ciphertext, EncodingError, Key, Message, Ring, RingElement};
+use crate::{Cipher, Ciphertext as Ciphtxt, EncodingError, Key, Message, Ring, RingElement};
 use rand::{CryptoRng, Rng};
-use std::str::FromStr;
+use std::{ops::Deref, str::FromStr};
+
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
+pub struct Ciphertext(Ciphtxt);
+
+impl Deref for Ciphertext {
+    type Target = Ciphtxt;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl FromStr for Ciphertext {
+    type Err = EncodingError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Ciphertext(Ciphtxt::from_str(s)?))
+    }
+}
 
 /// An implementation of the Latin Shift Cipher.
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
@@ -39,7 +57,7 @@ impl Cipher for ShiftCipher {
     /// let ciphertxt = ShiftCipher::encrypt(&msg, &key);
     /// ```
     fn encrypt(msg: &Self::Message, key: &Self::Key) -> Self::Ciphertext {
-        msg.0.iter().map(|&i| i + key.0).collect()
+        Ciphertext(msg.0.iter().map(|&i| i + key.0).collect())
     }
 
     // TODO! refactor, generalize
@@ -94,11 +112,11 @@ impl Cipher for ShiftCipher {
     /// easily see the preservation of patterns:
     /// \n plaintext is {}, ciphertext is {},
     ///  and decryption under a random key gives {}",
-    /// small_msg, small_ciphertext,
+    /// small_msg, *small_ciphertext,
     /// small_decryption)
     /// ```
     fn decrypt(ciphertxt: &Self::Ciphertext, key: &Self::Key) -> Self::Message {
-        ciphertxt.0.iter().map(|&i| i - key.0).collect()
+        ciphertxt.0 .0.iter().map(|&i| i - key.0).collect()
     }
 }
 
@@ -238,11 +256,11 @@ mod tests {
 
     // Encrypted "wewillmeetatmidnight" message with key=11, from Example 1.1,
     // Stinson 3rd Edition, Example 2.1 Stinson 4th Edition
-    thread_local! (static CIPH0: Ciphertext = Ciphertext(vec![RingElement(7), RingElement(15), 
+    thread_local! (static CIPH0: Ciphertext = Ciphertext(Ciphtxt(vec![RingElement(7), RingElement(15), 
             RingElement(7), RingElement(19), RingElement(22), RingElement(22),
             RingElement(23), RingElement(15), RingElement(15), RingElement(4),
             RingElement(11), RingElement(4),
-            RingElement(23), RingElement(19), RingElement(14), RingElement(24), RingElement(19), RingElement(17), RingElement(18), RingElement(4)]));
+            RingElement(23), RingElement(19), RingElement(14), RingElement(24), RingElement(19), RingElement(17), RingElement(18), RingElement(4)])));
 
     // Encrypted "wewillmeetatmidnight" as a string, from Example 1.1 Stinson 3rd
     // Edition, Example 2.1 Stinson 4th Edition

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -35,7 +35,7 @@ impl Cipher for ShiftCipher {
     /// # use rand::thread_rng;
     /// # let mut rng = thread_rng();
     /// # let key = Key::new(&mut rng);
-    ///  let msg = <ShiftCipher as Cipher>::Message::new("thisisanawkwardapichoice").expect("This example is hardcoded; it should work!");
+    /// # let msg = <ShiftCipher as Cipher>::Message::new("thisisanawkwardapichoice").expect("This example is hardcoded; it should work!");
     /// let ciphertxt = ShiftCipher::encrypt(&msg, &key);
     /// ```
     fn encrypt(msg: &Self::Message, key: &Self::Key) -> Self::Ciphertext {

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -77,10 +77,6 @@ impl FromIterator<RingElement> for Message {
     }
 }
 
-/// An implementation of the Latin Shift Cipher.
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
-pub struct ShiftCipher;
-
 /// A cryptographic key for the Latin Shift Cipher.
 // Crypto TODO: Keys should always contain context.
 // We *could* implement `Copy` and `Clone` here.
@@ -153,6 +149,10 @@ impl From<RingElement> for Key {
         Key(item)
     }
 }
+
+/// An implementation of the Latin Shift Cipher.
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
+pub struct ShiftCipher;
 
 impl CipherTrait for ShiftCipher {
     type Message = Message;

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -32,12 +32,13 @@ impl Cipher for Shift {
     ///
     /// # Examples
     /// ```
-    /// # use classical_crypto::{Cipher, shift::Shift, Ciphertext, Key, Message};
+    /// # use classical_crypto::{Cipher, Key, shift::Shift};
     /// # use rand::thread_rng;
     /// # let mut rng = thread_rng();
-    /// # let key = Key::new(&mut rng);
-    /// # let msg = Message::new("thisisanawkwardapichoice").expect("This example is hardcoded; it should work!");
-    /// let ciphertxt = Shift::encrypt(&msg, &key);
+    /// # let key = Key::new(&mut rng); 
+    ///  let msg = <Shift as Cipher>::Message::new("thisisanawkwardapichoice").expect("This example is hardcoded; it should work!"); 
+    /// let ciphertxt = Shift::encrypt(&msg, &key); 
+    /// 
     /// ```
     fn encrypt(msg: &Self::Message, key: &Self::Key) -> Self::Ciphertext {
         msg.0.iter().map(|&i| i + key.0).collect()
@@ -48,12 +49,12 @@ impl Cipher for Shift {
     ///
     /// # Examples
     /// ```
-    /// # use classical_crypto::{Cipher, shift::Shift, Ciphertext, Key, Message};
+    /// # use classical_crypto::{Cipher, Key, shift::Shift};
     /// # use rand::thread_rng;
     /// #
     /// # let mut rng = thread_rng();
     /// # let key = Key::new(&mut rng);
-    /// # let msg = Message::new("thisisanawkwardapichoice").expect("This example is hardcoded; it should work!");
+    /// # let msg = <Shift as Cipher>::Message::new("thisisanawkwardapichoice").expect("This example is hardcoded; it should work!");
     /// # let ciphertxt = Shift::encrypt(&msg, &key);
     /// let decrypted = Shift::decrypt(&ciphertxt, &key);
     ///
@@ -70,7 +71,7 @@ impl Cipher for Shift {
     /// ```
     ///
     /// ```
-    /// # use classical_crypto::{Cipher, shift::Shift, Ciphertext, Key, Message};
+    /// # use classical_crypto::{Cipher, Key, shift::Shift};
     /// # use rand::thread_rng;
     /// #
     /// # let mut rng = thread_rng();
@@ -84,7 +85,7 @@ impl Cipher for Shift {
     /// // one sample, one ciphertext may not be enough to definitively
     /// // break the system with a brute force attack. But likely there
     /// // is other context available to validate possible plaintexts.
-    /// let small_msg = Message::new("dad").expect("This example is hardcoded; it should work!");
+    /// let small_msg = <Shift as Cipher>::Message::new("dad").expect("This example is hardcoded; it should work!");
     /// let small_ciphertext = Shift::encrypt(&small_msg, &key);
     /// // This will also decrypt the message properly with probability 1/26
     /// // which is of course a huge probability of success.
@@ -119,7 +120,7 @@ impl Key for ShiftKey {
     ///
     /// # Examples
     /// ```
-    /// # use classical_crypto::{Ciphertext, Key, shift::ShiftKey, Message};
+    /// # use classical_crypto::{Cipher, Key, shift::Shift};
     /// // Don't forget to include the `rand` crate!
     /// use rand::thread_rng;
     /// //
@@ -127,7 +128,7 @@ impl Key for ShiftKey {
     /// let mut rng = thread_rng();
     /// //
     /// // Generate a key
-    /// let key = ShiftKey::new(&mut rng);
+    /// let key = <Shift as Cipher>::Key::new(&mut rng);
     /// ```
     // Note: Keys must always be chosen according to a uniform distribution on the
     // underlying key space, i.e., the ring Z/26Z for the Latin Alphabet cipher.
@@ -141,7 +142,7 @@ impl ShiftKey {
     ///
     /// # Examples
     /// ```
-    /// # use classical_crypto::{Ciphertext, Key, shift::ShiftKey, Message};
+    /// # use classical_crypto::{Cipher, Key, shift::Shift};
     /// # // Don't forget to include the `rand` crate!
     /// # use rand::thread_rng;
     /// # //
@@ -149,7 +150,7 @@ impl ShiftKey {
     /// # let mut rng = thread_rng();
     /// # //
     /// # // Generate a key
-    /// # let key = ShiftKey::new(&mut rng);
+    /// # let key = <Shift as Cipher>::Key::new(&mut rng);
     /// //
     /// // We can export a key for external storage or other uses.
     /// // This method does not do anything special for secure key

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -3,7 +3,9 @@
 //! &#x2124;/26&#x2124;. As the name implies, ciphertexts are shifts (computed
 //! using modular arithmetic) of the corresponding plaintexts, so the _key
 //! space_ is &#x2124;/26&#x2124;. as well.
-use crate::{Cipher, Ciphertext as Ciphtxt, EncodingError, Key, Message as Msg, Ring, RingElement};
+use crate::{
+    CipherTrait, Ciphertext as Ciphtxt, EncodingError, KeyTrait, Message as Msg, Ring, RingElement,
+};
 use rand::{CryptoRng, Rng};
 use std::{fmt::Display, str::FromStr};
 
@@ -85,12 +87,12 @@ pub struct ShiftCipher;
 // We do not because we want to discourage making copies of secrets.
 // However there is a lot more to best practices for handling keys than this.
 #[derive(Debug, Eq, PartialEq)]
-pub struct ShiftKey(RingElement);
+pub struct Key(RingElement);
 
-impl Cipher for ShiftCipher {
+impl CipherTrait for ShiftCipher {
     type Message = Message;
     type Ciphertext = Ciphertext;
-    type Key = ShiftKey;
+    type Key = Key;
 
     type EncryptionError = EncryptionError;
     type DecryptionError = DecryptionError;
@@ -99,11 +101,11 @@ impl Cipher for ShiftCipher {
     ///
     /// # Examples
     /// ```
-    /// # use classical_crypto::{Cipher, Key, shift::ShiftCipher};
+    /// # use classical_crypto::{CipherTrait, KeyTrait, shift::{ShiftCipher, Key, Message, Ciphertext}};
     /// # use rand::thread_rng;
     /// # let mut rng = thread_rng();
     /// # let key = Key::new(&mut rng);
-    /// # let msg = <ShiftCipher as Cipher>::Message::new("thisisanawkwardapichoice").expect("This example is hardcoded; it should work!");
+    /// # let msg = Message::new("thisisanawkwardapichoice").expect("This example is hardcoded; it should work!");
     /// let ciphertxt = ShiftCipher::encrypt(&msg, &key);
     /// ```
     fn encrypt(msg: &Self::Message, key: &Self::Key) -> Self::Ciphertext {
@@ -115,12 +117,12 @@ impl Cipher for ShiftCipher {
     ///
     /// # Examples
     /// ```
-    /// # use classical_crypto::{Cipher, Key, shift::ShiftCipher};
+    /// # use classical_crypto::{CipherTrait, KeyTrait, shift::{ShiftCipher, Key, Message, Ciphertext}};
     /// # use rand::thread_rng;
     /// #
     /// # let mut rng = thread_rng();
     /// # let key = Key::new(&mut rng);
-    /// # let msg = <ShiftCipher as Cipher>::Message::new("thisisanawkwardapichoice").expect("This example is hardcoded; it should work!");
+    /// # let msg = Message::new("thisisanawkwardapichoice").expect("This example is hardcoded; it should work!");
     /// # let ciphertxt = ShiftCipher::encrypt(&msg, &key);
     /// let decrypted = ShiftCipher::decrypt(&ciphertxt, &key);
     ///
@@ -137,7 +139,7 @@ impl Cipher for ShiftCipher {
     /// ```
     ///
     /// ```
-    /// # use classical_crypto::{Cipher, Key, shift::ShiftCipher};
+    /// # use classical_crypto::{CipherTrait, KeyTrait, shift::{ShiftCipher, Key, Message, Ciphertext}};
     /// # use rand::thread_rng;
     /// #
     /// # let mut rng = thread_rng();
@@ -151,7 +153,7 @@ impl Cipher for ShiftCipher {
     /// // one sample, one ciphertext may not be enough to definitively
     /// // break the system with a brute force attack. But likely there
     /// // is other context available to validate possible plaintexts.
-    /// let small_msg = <ShiftCipher as Cipher>::Message::new("dad").expect("This example is hardcoded; it should work!");
+    /// let small_msg = Message::new("dad").expect("This example is hardcoded; it should work!");
     /// let small_ciphertext = ShiftCipher::encrypt(&small_msg, &key);
     /// // This will also decrypt the message properly with probability 1/26
     /// // which is of course a huge probability of success.
@@ -171,7 +173,7 @@ impl Cipher for ShiftCipher {
 }
 
 // TODO: refactor, prep for Substitution Cipher
-impl Key for ShiftKey {
+impl KeyTrait for Key {
     /// Generate a cryptographic key uniformly at random from the key space.
     ///
     /// Note that the mathematical description of the Latin Shift Cipher,
@@ -186,7 +188,7 @@ impl Key for ShiftKey {
     ///
     /// # Examples
     /// ```
-    /// # use classical_crypto::{Cipher, Key, shift::ShiftCipher};
+    /// # use classical_crypto::{CipherTrait, KeyTrait, shift::{ShiftCipher, Key, Message, Ciphertext}};
     /// // Don't forget to include the `rand` crate!
     /// use rand::thread_rng;
     /// //
@@ -194,7 +196,7 @@ impl Key for ShiftKey {
     /// let mut rng = thread_rng();
     /// //
     /// // Generate a key
-    /// let key = <ShiftCipher as Cipher>::Key::new(&mut rng);
+    /// let key = Key::new(&mut rng);
     /// ```
     // Note: Keys must always be chosen according to a uniform distribution on the
     // underlying key space, i.e., the ring Z/26Z for the Latin Alphabet cipher.
@@ -208,7 +210,7 @@ impl ShiftCipher {
     ///
     /// # Examples
     /// ```
-    /// # use classical_crypto::{Cipher, Key, shift::ShiftCipher};
+    /// # use classical_crypto::{CipherTrait, KeyTrait, shift::{ShiftCipher, Key, Message, Ciphertext}};
     /// # // Don't forget to include the `rand` crate!
     /// # use rand::thread_rng;
     /// # //
@@ -216,7 +218,7 @@ impl ShiftCipher {
     /// # let mut rng = thread_rng();
     /// # //
     /// # // Generate a key
-    /// # let key = <ShiftCipher as Cipher>::Key::new(&mut rng);
+    /// # let key = Key::new(&mut rng);
     /// //
     /// // We can export a key for external storage or other uses.
     /// // This method does not do anything special for secure key
@@ -225,7 +227,7 @@ impl ShiftCipher {
     /// // Use caution.
     /// println!("Here is our key value: {}", ShiftCipher::insecure_key_export(&key));
     /// ```
-    pub fn insecure_key_export(key: &<Self as Cipher>::Key) -> String {
+    pub fn insecure_key_export(key: &<Self as CipherTrait>::Key) -> String {
         key.0.into_inner().to_string()
     }
 }
@@ -239,7 +241,7 @@ impl ShiftCipher {
 /// inclusive. While it would be a simple matter to accept _any_ integer as
 /// input and map to the ring of integers, we chose not to do so for clarity of
 /// use.
-impl FromStr for ShiftKey {
+impl FromStr for Key {
     type Err = EncodingError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -249,16 +251,16 @@ impl FromStr for ShiftKey {
         };
 
         match key {
-            x if (0..=25).contains(&x) => Ok(ShiftKey::from(RingElement::from_i8(key))),
+            x if (0..=25).contains(&x) => Ok(Key::from(RingElement::from_i8(key))),
             _ => Err(EncodingError),
         }
     }
 }
 
 // TODO: refactor, prep for Substitution Cipher
-impl From<RingElement> for ShiftKey {
+impl From<RingElement> for Key {
     fn from(item: RingElement) -> Self {
-        ShiftKey(item)
+        Key(item)
     }
 }
 
@@ -319,7 +321,7 @@ mod tests {
     // Example 1.1, Stinson 3rd Edition, Example 2.1 Stinson 4th Edition.
     #[test]
     fn enc_dec_basic() {
-        let key0 = ShiftKey(RingElement(11));
+        let key0 = Key(RingElement(11));
 
         let ciph0 = ShiftCipher::encrypt(&Message::new("wewillmeetatmidnight").unwrap(), &key0);
 
@@ -335,8 +337,8 @@ mod tests {
     fn enc_dec_random_keys() {
         let mut rng = rand::thread_rng();
 
-        let key1 = Key::new(&mut rng);
-        let key2 = Key::new(&mut rng);
+        let key1 = KeyTrait::new(&mut rng);
+        let key2 = KeyTrait::new(&mut rng);
 
         let msg1 = Message::new("thisisatest").unwrap();
         let msg2 = Message::new("thisisanothertest").unwrap();
@@ -365,8 +367,8 @@ mod tests {
     fn enc_dec_reprod_rand() {
         let mut rng = reprod_rng();
 
-        let key1 = ShiftKey(RingElement(rng.gen_range(0..RingElement::MODULUS)));
-        let key2 = ShiftKey(RingElement(rng.gen_range(0..RingElement::MODULUS)));
+        let key1 = Key(RingElement(rng.gen_range(0..RingElement::MODULUS)));
+        let key2 = Key(RingElement(rng.gen_range(0..RingElement::MODULUS)));
 
         let msg1 = Message::new("thisisyetanothertestmessage").unwrap();
 

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -47,7 +47,7 @@ impl Cipher for ShiftCipher {
     ///
     /// # Examples
     /// ```
-    /// # use classical_crypto::{Cipher, Key, ShiftCipher};
+    /// # use classical_crypto::{Cipher, Key, shift::ShiftCipher};
     /// # use rand::thread_rng;
     /// # let mut rng = thread_rng();
     /// # let key = Key::new(&mut rng);
@@ -63,7 +63,7 @@ impl Cipher for ShiftCipher {
     ///
     /// # Examples
     /// ```
-    /// # use classical_crypto::{Cipher, Key, ShiftCipher};
+    /// # use classical_crypto::{Cipher, Key, shift::ShiftCipher};
     /// # use rand::thread_rng;
     /// #
     /// # let mut rng = thread_rng();
@@ -85,7 +85,7 @@ impl Cipher for ShiftCipher {
     /// ```
     ///
     /// ```
-    /// # use classical_crypto::{Cipher, Key, ShiftCipher};
+    /// # use classical_crypto::{Cipher, Key, shift::ShiftCipher};
     /// # use rand::thread_rng;
     /// #
     /// # let mut rng = thread_rng();
@@ -134,7 +134,7 @@ impl Key for ShiftKey {
     ///
     /// # Examples
     /// ```
-    /// # use classical_crypto::{Cipher, Key, ShiftCipher};
+    /// # use classical_crypto::{Cipher, Key, shift::ShiftCipher};
     /// // Don't forget to include the `rand` crate!
     /// use rand::thread_rng;
     /// //
@@ -156,7 +156,7 @@ impl ShiftCipher {
     ///
     /// # Examples
     /// ```
-    /// # use classical_crypto::{Cipher, Key, ShiftCipher};
+    /// # use classical_crypto::{Cipher, Key, shift::ShiftCipher};
     /// # // Don't forget to include the `rand` crate!
     /// # use rand::thread_rng;
     /// # //

--- a/classical_crypto/tests/integration_test.rs
+++ b/classical_crypto/tests/integration_test.rs
@@ -1,9 +1,6 @@
 //! These integration tests exercise the public API of the crate, but they may
 //! not be entirely sensible as integration tests.
-use classical_crypto::{
-    shift::{Shift, ShiftKey},
-    Cipher, Ciphertext, Key, Message,
-};
+use classical_crypto::{Cipher, Ciphertext, Key, Message, ShiftCipher};
 use rand::thread_rng;
 use std::str::FromStr;
 
@@ -19,17 +16,17 @@ fn generate_and_use_key() {
     assert_eq!(msg, Message::from_str("thisisanawkwardapichoice").unwrap());
 
     // Encrypt the test message.
-    let ciphertxt = Shift::encrypt(&msg, &key0);
+    let ciphertxt = ShiftCipher::encrypt(&msg, &key0);
 
     // If we decrypt our ciphertext with the correct key, we
     // get our original message back.
-    let decrypted = Shift::decrypt(&ciphertxt, &key0);
+    let decrypted = ShiftCipher::decrypt(&ciphertxt, &key0);
     assert_eq!(decrypted, msg);
 
     // If we decrypt using an incorrect key, we do not get
     //  our original message back
     if key0 != key1 {
-        assert_ne!(Shift::decrypt(&ciphertxt, &key1), msg);
+        assert_ne!(ShiftCipher::decrypt(&ciphertxt, &key1), msg);
     }
 
     // We can create ciphertexts from strings, too
@@ -63,8 +60,8 @@ fn short_msg_example() {
 
     // Set two fixed keys in order to reiterate how patterns are preserved
     // in Latin shift cipher.
-    let fixed_key_0 = ShiftKey::from_str("3");
-    let fixed_key_1 = ShiftKey::from_str("9");
+    let fixed_key_0 = <ShiftCipher as Cipher>::Key::from_str("3");
+    let fixed_key_1 = <ShiftCipher as Cipher>::Key::from_str("9");
 
     // Key encoding should work
     assert!(&fixed_key_0.is_ok());
@@ -74,8 +71,8 @@ fn short_msg_example() {
     let fixed_key_0 = fixed_key_0.unwrap();
     let fixed_key_1 = fixed_key_1.unwrap();
 
-    let small_ciphertext = Shift::encrypt(&small_msg_0, &fixed_key_0);
-    let small_decryption = Shift::decrypt(&small_ciphertext, &fixed_key_0);
+    let small_ciphertext = ShiftCipher::encrypt(&small_msg_0, &fixed_key_0);
+    let small_decryption = ShiftCipher::decrypt(&small_ciphertext, &fixed_key_0);
 
     // Encryption followed by decryption with the correct gets us back the original
     // message
@@ -84,5 +81,8 @@ fn short_msg_example() {
 
     // Encryption followed by decryption with an incorrect key gets us back a still
     // intelligible message somtimes.
-    assert_eq!(Shift::decrypt(&small_ciphertext, &fixed_key_1), small_msg_1);
+    assert_eq!(
+        ShiftCipher::decrypt(&small_ciphertext, &fixed_key_1),
+        small_msg_1
+    );
 }

--- a/classical_crypto/tests/integration_test.rs
+++ b/classical_crypto/tests/integration_test.rs
@@ -1,6 +1,6 @@
 //! These integration tests exercise the public API of the crate, but they may
 //! not be entirely sensible as integration tests.
-use classical_crypto::{CipherText, Key, Message};
+use classical_crypto::{shift::Shift, Cipher, Ciphertext, Key, Message};
 use rand::thread_rng;
 use std::str::FromStr;
 
@@ -16,21 +16,21 @@ fn generate_and_use_key() {
     assert_eq!(msg, Message::from_str("thisisanawkwardapichoice").unwrap());
 
     // Encrypt the test message.
-    let ciphertxt = Message::encrypt(&msg, &key0);
+    let ciphertxt = Shift::encrypt(&msg, &key0);
 
     // If we decrypt our ciphertext with the correct key, we
     // get our original message back.
-    let decrypted = CipherText::decrypt(&ciphertxt, &key0);
+    let decrypted = Shift::decrypt(&ciphertxt, &key0);
     assert_eq!(decrypted, msg);
 
     // If we decrypt using an incorrect key, we do not get
     //  our original message back
     if key0 != key1 {
-        assert_ne!(CipherText::decrypt(&ciphertxt, &key1), msg);
+        assert_ne!(Shift::decrypt(&ciphertxt, &key1), msg);
     }
 
     // We can create ciphertexts from strings, too
-    let garbage_ciphertext = CipherText::from_str("THISISNOTGOINGTODECRYPTSENSIBLY").unwrap();
+    let garbage_ciphertext = Ciphertext::from_str("THISISNOTGOINGTODECRYPTSENSIBLY").unwrap();
     assert_eq!(
         garbage_ciphertext.to_string(),
         "THISISNOTGOINGTODECRYPTSENSIBLY"
@@ -71,8 +71,8 @@ fn short_msg_example() {
     let fixed_key_0 = fixed_key_0.unwrap();
     let fixed_key_1 = fixed_key_1.unwrap();
 
-    let small_ciphertext = Message::encrypt(&small_msg_0, &fixed_key_0);
-    let small_decryption = CipherText::decrypt(&small_ciphertext, &fixed_key_0);
+    let small_ciphertext = Shift::encrypt(&small_msg_0, &fixed_key_0);
+    let small_decryption = Shift::decrypt(&small_ciphertext, &fixed_key_0);
 
     // Encryption followed by decryption with the correct gets us back the original
     // message
@@ -81,8 +81,5 @@ fn short_msg_example() {
 
     // Encryption followed by decryption with an incorrect key gets us back a still
     // intelligible message somtimes.
-    assert_eq!(
-        CipherText::decrypt(&small_ciphertext, &fixed_key_1),
-        small_msg_1
-    );
+    assert_eq!(Shift::decrypt(&small_ciphertext, &fixed_key_1), small_msg_1);
 }

--- a/classical_crypto/tests/integration_test.rs
+++ b/classical_crypto/tests/integration_test.rs
@@ -1,6 +1,6 @@
 //! These integration tests exercise the public API of the crate, but they may
 //! not be entirely sensible as integration tests.
-use classical_crypto::{Cipher, Ciphertext, Key, Message, ShiftCipher};
+use classical_crypto::{Cipher, Key, ShiftCipher};
 use rand::thread_rng;
 use std::str::FromStr;
 
@@ -11,9 +11,12 @@ fn generate_and_use_key() {
     let key1 = Key::new(&mut rng);
 
     // Exercise the `new` associated function.
-    let msg = Message::new("thisisanawkwardapichoice").unwrap();
+    let msg = <ShiftCipher as Cipher>::Message::new("thisisanawkwardapichoice").unwrap();
     // We could also have used the `FromStr` implementation for `Message`.
-    assert_eq!(msg, Message::from_str("thisisanawkwardapichoice").unwrap());
+    assert_eq!(
+        msg,
+        <ShiftCipher as Cipher>::Message::from_str("thisisanawkwardapichoice").unwrap()
+    );
 
     // Encrypt the test message.
     let ciphertxt = ShiftCipher::encrypt(&msg, &key0);
@@ -30,7 +33,8 @@ fn generate_and_use_key() {
     }
 
     // We can create ciphertexts from strings, too
-    let garbage_ciphertext = Ciphertext::from_str("THISISNOTGOINGTODECRYPTSENSIBLY").unwrap();
+    let garbage_ciphertext =
+        <ShiftCipher as Cipher>::Ciphertext::from_str("THISISNOTGOINGTODECRYPTSENSIBLY").unwrap();
     assert_eq!(
         garbage_ciphertext.to_string(),
         "THISISNOTGOINGTODECRYPTSENSIBLY"
@@ -47,8 +51,8 @@ fn short_msg_example() {
     // one sample, one ciphertext may not be enough to definitively
     // break the system with a brute force attack. But likely there
     // is other context available to validate possible plaintexts.
-    let small_msg_0 = Message::from_str("mom");
-    let small_msg_1 = Message::from_str("gig");
+    let small_msg_0 = <ShiftCipher as Cipher>::Message::from_str("mom");
+    let small_msg_1 = <ShiftCipher as Cipher>::Message::from_str("gig");
 
     // Message encoding should work
     assert!(small_msg_0.is_ok());

--- a/classical_crypto/tests/integration_test.rs
+++ b/classical_crypto/tests/integration_test.rs
@@ -1,22 +1,22 @@
 //! These integration tests exercise the public API of the crate, but they may
 //! not be entirely sensible as integration tests.
-use classical_crypto::{
-    shift::{Shift, ShiftKey},
-    Cipher, Ciphertext, Key, Message,
-};
+use classical_crypto::{shift::Shift, Cipher};
 use rand::thread_rng;
 use std::str::FromStr;
 
 #[test]
 fn generate_and_use_key() {
     let mut rng = thread_rng();
-    let key0 = Key::new(&mut rng);
-    let key1 = Key::new(&mut rng);
+    let key0 = Shift::gen_key(&mut rng);
+    let key1 = Shift::gen_key(&mut rng);
 
     // Exercise the `new` associated function.
-    let msg = Message::new("thisisanawkwardapichoice").unwrap();
+    let msg = <Shift as Cipher>::Message::new("thisisanawkwardapichoice").unwrap();
     // We could also have used the `FromStr` implementation for `Message`.
-    assert_eq!(msg, Message::from_str("thisisanawkwardapichoice").unwrap());
+    assert_eq!(
+        msg,
+        <Shift as Cipher>::Message::from_str("thisisanawkwardapichoice").unwrap()
+    );
 
     // Encrypt the test message.
     let ciphertxt = Shift::encrypt(&msg, &key0);
@@ -33,7 +33,8 @@ fn generate_and_use_key() {
     }
 
     // We can create ciphertexts from strings, too
-    let garbage_ciphertext = Ciphertext::from_str("THISISNOTGOINGTODECRYPTSENSIBLY").unwrap();
+    let garbage_ciphertext =
+        <Shift as Cipher>::Ciphertext::from_str("THISISNOTGOINGTODECRYPTSENSIBLY").unwrap();
     assert_eq!(
         garbage_ciphertext.to_string(),
         "THISISNOTGOINGTODECRYPTSENSIBLY"
@@ -50,8 +51,8 @@ fn short_msg_example() {
     // one sample, one ciphertext may not be enough to definitively
     // break the system with a brute force attack. But likely there
     // is other context available to validate possible plaintexts.
-    let small_msg_0 = Message::from_str("mom");
-    let small_msg_1 = Message::from_str("gig");
+    let small_msg_0 = <Shift as Cipher>::Message::from_str("mom");
+    let small_msg_1 = <Shift as Cipher>::Message::from_str("gig");
 
     // Message encoding should work
     assert!(small_msg_0.is_ok());
@@ -63,8 +64,8 @@ fn short_msg_example() {
 
     // Set two fixed keys in order to reiterate how patterns are preserved
     // in Latin shift cipher.
-    let fixed_key_0 = ShiftKey::from_str("3");
-    let fixed_key_1 = ShiftKey::from_str("9");
+    let fixed_key_0 = <Shift as Cipher>::Key::from_str("3");
+    let fixed_key_1 = <Shift as Cipher>::Key::from_str("9");
 
     // Key encoding should work
     assert!(&fixed_key_0.is_ok());

--- a/classical_crypto/tests/integration_test.rs
+++ b/classical_crypto/tests/integration_test.rs
@@ -1,22 +1,22 @@
 //! These integration tests exercise the public API of the crate, but they may
 //! not be entirely sensible as integration tests.
-use classical_crypto::{shift::Shift, Cipher};
+use classical_crypto::{
+    shift::{Shift, ShiftKey},
+    Cipher, Ciphertext, Key, Message,
+};
 use rand::thread_rng;
 use std::str::FromStr;
 
 #[test]
 fn generate_and_use_key() {
     let mut rng = thread_rng();
-    let key0 = Shift::gen_key(&mut rng);
-    let key1 = Shift::gen_key(&mut rng);
+    let key0 = Key::new(&mut rng);
+    let key1 = Key::new(&mut rng);
 
     // Exercise the `new` associated function.
-    let msg = <Shift as Cipher>::Message::new("thisisanawkwardapichoice").unwrap();
+    let msg = Message::new("thisisanawkwardapichoice").unwrap();
     // We could also have used the `FromStr` implementation for `Message`.
-    assert_eq!(
-        msg,
-        <Shift as Cipher>::Message::from_str("thisisanawkwardapichoice").unwrap()
-    );
+    assert_eq!(msg, Message::from_str("thisisanawkwardapichoice").unwrap());
 
     // Encrypt the test message.
     let ciphertxt = Shift::encrypt(&msg, &key0);
@@ -33,8 +33,7 @@ fn generate_and_use_key() {
     }
 
     // We can create ciphertexts from strings, too
-    let garbage_ciphertext =
-        <Shift as Cipher>::Ciphertext::from_str("THISISNOTGOINGTODECRYPTSENSIBLY").unwrap();
+    let garbage_ciphertext = Ciphertext::from_str("THISISNOTGOINGTODECRYPTSENSIBLY").unwrap();
     assert_eq!(
         garbage_ciphertext.to_string(),
         "THISISNOTGOINGTODECRYPTSENSIBLY"
@@ -51,8 +50,8 @@ fn short_msg_example() {
     // one sample, one ciphertext may not be enough to definitively
     // break the system with a brute force attack. But likely there
     // is other context available to validate possible plaintexts.
-    let small_msg_0 = <Shift as Cipher>::Message::from_str("mom");
-    let small_msg_1 = <Shift as Cipher>::Message::from_str("gig");
+    let small_msg_0 = Message::from_str("mom");
+    let small_msg_1 = Message::from_str("gig");
 
     // Message encoding should work
     assert!(small_msg_0.is_ok());
@@ -64,8 +63,8 @@ fn short_msg_example() {
 
     // Set two fixed keys in order to reiterate how patterns are preserved
     // in Latin shift cipher.
-    let fixed_key_0 = <Shift as Cipher>::Key::from_str("3");
-    let fixed_key_1 = <Shift as Cipher>::Key::from_str("9");
+    let fixed_key_0 = ShiftKey::from_str("3");
+    let fixed_key_1 = ShiftKey::from_str("9");
 
     // Key encoding should work
     assert!(&fixed_key_0.is_ok());

--- a/classical_crypto/tests/integration_test.rs
+++ b/classical_crypto/tests/integration_test.rs
@@ -1,6 +1,9 @@
 //! These integration tests exercise the public API of the crate, but they may
 //! not be entirely sensible as integration tests.
-use classical_crypto::{Cipher, Key, ShiftCipher};
+use classical_crypto::{
+    shift::{Ciphertext, ShiftCipher},
+    Cipher, Key,
+};
 use rand::thread_rng;
 use std::str::FromStr;
 
@@ -33,8 +36,7 @@ fn generate_and_use_key() {
     }
 
     // We can create ciphertexts from strings, too
-    let garbage_ciphertext =
-        <ShiftCipher as Cipher>::Ciphertext::from_str("THISISNOTGOINGTODECRYPTSENSIBLY").unwrap();
+    let garbage_ciphertext = Ciphertext::from_str("THISISNOTGOINGTODECRYPTSENSIBLY").unwrap();
     assert_eq!(
         garbage_ciphertext.to_string(),
         "THISISNOTGOINGTODECRYPTSENSIBLY"

--- a/classical_crypto/tests/integration_test.rs
+++ b/classical_crypto/tests/integration_test.rs
@@ -1,7 +1,7 @@
 //! These integration tests exercise the public API of the crate, but they may
 //! not be entirely sensible as integration tests.
 use classical_crypto::{
-    shift::{Ciphertext, ShiftCipher},
+    shift::{Message, Ciphertext, ShiftCipher},
     Cipher, Key,
 };
 use rand::thread_rng;
@@ -14,11 +14,11 @@ fn generate_and_use_key() {
     let key1 = Key::new(&mut rng);
 
     // Exercise the `new` associated function.
-    let msg = <ShiftCipher as Cipher>::Message::new("thisisanawkwardapichoice").unwrap();
+    let msg = Message::new("thisisanawkwardapichoice").unwrap();
     // We could also have used the `FromStr` implementation for `Message`.
     assert_eq!(
         msg,
-        <ShiftCipher as Cipher>::Message::from_str("thisisanawkwardapichoice").unwrap()
+        Message::from_str("thisisanawkwardapichoice").unwrap()
     );
 
     // Encrypt the test message.
@@ -53,8 +53,8 @@ fn short_msg_example() {
     // one sample, one ciphertext may not be enough to definitively
     // break the system with a brute force attack. But likely there
     // is other context available to validate possible plaintexts.
-    let small_msg_0 = <ShiftCipher as Cipher>::Message::from_str("mom");
-    let small_msg_1 = <ShiftCipher as Cipher>::Message::from_str("gig");
+    let small_msg_0 = Message::from_str("mom");
+    let small_msg_1 = Message::from_str("gig");
 
     // Message encoding should work
     assert!(small_msg_0.is_ok());

--- a/classical_crypto/tests/integration_test.rs
+++ b/classical_crypto/tests/integration_test.rs
@@ -1,6 +1,9 @@
 //! These integration tests exercise the public API of the crate, but they may
 //! not be entirely sensible as integration tests.
-use classical_crypto::{shift::Shift, Cipher, Ciphertext, Key, Message};
+use classical_crypto::{
+    shift::{Shift, ShiftKey},
+    Cipher, Ciphertext, Key, Message,
+};
 use rand::thread_rng;
 use std::str::FromStr;
 
@@ -60,8 +63,8 @@ fn short_msg_example() {
 
     // Set two fixed keys in order to reiterate how patterns are preserved
     // in Latin shift cipher.
-    let fixed_key_0 = Key::from_str("3");
-    let fixed_key_1 = Key::from_str("9");
+    let fixed_key_0 = ShiftKey::from_str("3");
+    let fixed_key_1 = ShiftKey::from_str("9");
 
     // Key encoding should work
     assert!(&fixed_key_0.is_ok());

--- a/classical_crypto/tests/integration_test.rs
+++ b/classical_crypto/tests/integration_test.rs
@@ -1,8 +1,8 @@
 //! These integration tests exercise the public API of the crate, but they may
 //! not be entirely sensible as integration tests.
 use classical_crypto::{
-    shift::{Message, Ciphertext, ShiftCipher},
-    Cipher, Key,
+    shift::{Ciphertext, Key, Message, ShiftCipher},
+    CipherTrait, KeyTrait,
 };
 use rand::thread_rng;
 use std::str::FromStr;
@@ -16,10 +16,7 @@ fn generate_and_use_key() {
     // Exercise the `new` associated function.
     let msg = Message::new("thisisanawkwardapichoice").unwrap();
     // We could also have used the `FromStr` implementation for `Message`.
-    assert_eq!(
-        msg,
-        Message::from_str("thisisanawkwardapichoice").unwrap()
-    );
+    assert_eq!(msg, Message::from_str("thisisanawkwardapichoice").unwrap());
 
     // Encrypt the test message.
     let ciphertxt = ShiftCipher::encrypt(&msg, &key0);
@@ -66,8 +63,8 @@ fn short_msg_example() {
 
     // Set two fixed keys in order to reiterate how patterns are preserved
     // in Latin shift cipher.
-    let fixed_key_0 = <ShiftCipher as Cipher>::Key::from_str("3");
-    let fixed_key_1 = <ShiftCipher as Cipher>::Key::from_str("9");
+    let fixed_key_0 = Key::from_str("3");
+    let fixed_key_1 = Key::from_str("9");
 
     // Key encoding should work
     assert!(&fixed_key_0.is_ok());

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -3,7 +3,7 @@ use crate::{
     io_helper::process_input,
     menu::{ConsentMenu, DecryptMenu, Menu},
 };
-use classical_crypto::{shift::Shift, Cipher, Ciphertext, Key, Message};
+use classical_crypto::{shift::Shift, Cipher, Ciphertext, Message};
 use rand::thread_rng;
 use std::error::Error;
 
@@ -14,7 +14,7 @@ pub fn make_key() -> Result<(), Box<dyn Error>> {
 
     loop {
         // Generate a key
-        let key = <Shift as Cipher>::Key::new(&mut rng);
+        let key = Shift::gen_key(&mut rng);
 
         println!("\nWe generated your key successfully!.");
         println!("\nWe shouldn't export your key (or say, save it in logs), but we can!");
@@ -98,7 +98,7 @@ pub fn computer_chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>>
     let mut rng = thread_rng();
 
     loop {
-        let key = <Shift as Cipher>::Key::new(&mut rng);
+        let key = Shift::gen_key(&mut rng);
         match try_decrypt(ciphertxt, key) {
             Ok(_) => break,
             Err(_) => continue, // TODO: How to handle different errors independently?

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -3,7 +3,7 @@ use crate::{
     io_helper::process_input,
     menu::{ConsentMenu, DecryptMenu, Menu},
 };
-use classical_crypto::{Cipher, Ciphertext, Key, Message, ShiftCipher};
+use classical_crypto::{Cipher, Key, Message, ShiftCipher};
 use rand::thread_rng;
 use std::error::Error;
 

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -3,7 +3,7 @@ use crate::{
     io_helper::process_input,
     menu::{ConsentMenu, DecryptMenu, Menu},
 };
-use classical_crypto::{shift::Shift, Cipher, Ciphertext, Message};
+use classical_crypto::{shift::Shift, Cipher, Key, Ciphertext, Message};
 use rand::thread_rng;
 use std::error::Error;
 
@@ -14,7 +14,7 @@ pub fn make_key() -> Result<(), Box<dyn Error>> {
 
     loop {
         // Generate a key
-        let key = Shift::gen_key(&mut rng);
+        let key = <Shift as Cipher>::Key::new(&mut rng);
 
         println!("\nWe generated your key successfully!.");
         println!("\nWe shouldn't export your key (or say, save it in logs), but we can!");
@@ -98,7 +98,7 @@ pub fn computer_chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>>
     let mut rng = thread_rng();
 
     loop {
-        let key = Shift::gen_key(&mut rng);
+        let key = <Shift as Cipher>::Key::new(&mut rng);
         match try_decrypt(ciphertxt, key) {
             Ok(_) => break,
             Err(_) => continue, // TODO: How to handle different errors independently?

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -4,7 +4,7 @@ use crate::{
     menu::{ConsentMenu, DecryptMenu, Menu},
 };
 use classical_crypto::{
-    shift::{Ciphertext, ShiftCipher},
+    shift::{Message, Ciphertext, ShiftCipher},
     Cipher, Key,
 };
 use rand::thread_rng;
@@ -42,7 +42,7 @@ pub fn make_key() -> Result<(), Box<dyn Error>> {
 pub fn encrypt() -> Result<(), Box<dyn Error>> {
     println!("\nPlease enter the message you want to encrypt:");
 
-    let msg: <ShiftCipher as Cipher>::Message = process_input(|| {
+    let msg: Message = process_input(|| {
         println!("\nWe only accept lowercase letters from the Latin Alphabet, in one of the most awkward \nAPI decisions ever.");
     })?;
 

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -49,7 +49,7 @@ pub fn encrypt() -> Result<(), Box<dyn Error>> {
         println!("{KEY_PROMPT}");
     })?;
 
-    println!("\nYour ciphertext is {}", ShiftCipher::encrypt(&msg, &key));
+    println!("\nYour ciphertext is {}", *ShiftCipher::encrypt(&msg, &key));
     println!("\nLook for patterns in your ciphertext. Could you definitively figure out the key and \noriginal plaintext message if you didn't already know it?");
 
     Ok(())
@@ -60,7 +60,7 @@ pub fn encrypt() -> Result<(), Box<dyn Error>> {
 pub fn decrypt(command: DecryptMenu) -> Result<(), Box<dyn Error>> {
     println!("\nEnter your ciphertext. Ciphertexts use characters only from the Latin Alphabet:");
 
-    let ciphertxt: Ciphertext = process_input(|| {
+    let ciphertxt: <ShiftCipher as Cipher>::Ciphertext = process_input(|| {
         println!("\nCiphertext must contain characters from the Latin Alphabet only.");
     })?;
 
@@ -79,7 +79,7 @@ pub fn decrypt(command: DecryptMenu) -> Result<(), Box<dyn Error>> {
 }
 
 /// Gets key from stdin and attempts to decrypt.
-pub fn chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>> {
+pub fn chosen_key(ciphertxt: &<ShiftCipher as Cipher>::Ciphertext) -> Result<(), Box<dyn Error>> {
     loop {
         println!("\nOK. Please enter a key now:");
         let key: <ShiftCipher as Cipher>::Key = process_input(|| {
@@ -94,7 +94,9 @@ pub fn chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>> {
 }
 
 /// Has computer choose key uniformly at random and attempts to decrypt.
-pub fn computer_chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>> {
+pub fn computer_chosen_key(
+    ciphertxt: &<ShiftCipher as Cipher>::Ciphertext,
+) -> Result<(), Box<dyn Error>> {
     let mut rng = thread_rng();
 
     loop {
@@ -109,7 +111,7 @@ pub fn computer_chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>>
 
 /// Decrypt with given key and ask whether to try again or not.
 pub fn try_decrypt(
-    ciphertxt: &Ciphertext,
+    ciphertxt: &<ShiftCipher as Cipher>::Ciphertext,
     key: <ShiftCipher as Cipher>::Key,
 ) -> Result<(), Box<dyn Error>> {
     println!(

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -3,7 +3,7 @@ use crate::{
     io_helper::process_input,
     menu::{ConsentMenu, DecryptMenu, Menu},
 };
-use classical_crypto::{Cipher, Key, Message, ShiftCipher};
+use classical_crypto::{Cipher, Key, ShiftCipher};
 use rand::thread_rng;
 use std::error::Error;
 
@@ -39,7 +39,7 @@ pub fn make_key() -> Result<(), Box<dyn Error>> {
 pub fn encrypt() -> Result<(), Box<dyn Error>> {
     println!("\nPlease enter the message you want to encrypt:");
 
-    let msg: Message = process_input(|| {
+    let msg: <ShiftCipher as Cipher>::Message = process_input(|| {
         println!("\nWe only accept lowercase letters from the Latin Alphabet, in one of the most awkward \nAPI decisions ever.");
     })?;
 

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -3,7 +3,7 @@ use crate::{
     io_helper::process_input,
     menu::{ConsentMenu, DecryptMenu, Menu},
 };
-use classical_crypto::{shift::Shift, Cipher, Key, Ciphertext, Message};
+use classical_crypto::{ShiftCipher, Cipher, Key, Ciphertext, Message};
 use rand::thread_rng;
 use std::error::Error;
 
@@ -14,11 +14,11 @@ pub fn make_key() -> Result<(), Box<dyn Error>> {
 
     loop {
         // Generate a key
-        let key = <Shift as Cipher>::Key::new(&mut rng);
+        let key = <ShiftCipher as Cipher>::Key::new(&mut rng);
 
         println!("\nWe generated your key successfully!.");
         println!("\nWe shouldn't export your key (or say, save it in logs), but we can!");
-        println!("Here it is: {}", key.insecure_export());
+        println!("Here it is: {}", ShiftCipher::insecure_key_export(&key));
         println!("\nAre you happy with your key?");
         ConsentMenu::print_menu();
 
@@ -45,11 +45,11 @@ pub fn encrypt() -> Result<(), Box<dyn Error>> {
 
     println!("\nNow, do you have a key that was generated uniformly at random that you remember and \nwould like to use? If yes, please enter your key. Otherwise, please pick a fresh key \nuniformly at random from the ring of integers modulo 26 yourself. \n\nYou won't be as good at this as a computer, but if you understand the cryptosystem \nyou are using (something we cryptographers routinely assume about other people, while \npretending that we aren't assuming this), you will probably not pick a key of 0, \nwhich is equivalent to sending your messages \"in the clear\", i.e., unencrypted. Good \nluck! \n\nGo ahead and enter your key now:");
 
-    let key: <Shift as Cipher>::Key = process_input(|| {
+    let key: <ShiftCipher as Cipher>::Key = process_input(|| {
         println!("{KEY_PROMPT}");
     })?;
 
-    println!("\nYour ciphertext is {}", Shift::encrypt(&msg, &key));
+    println!("\nYour ciphertext is {}", ShiftCipher::encrypt(&msg, &key));
     println!("\nLook for patterns in your ciphertext. Could you definitively figure out the key and \noriginal plaintext message if you didn't already know it?");
 
     Ok(())
@@ -82,7 +82,7 @@ pub fn decrypt(command: DecryptMenu) -> Result<(), Box<dyn Error>> {
 pub fn chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>> {
     loop {
         println!("\nOK. Please enter a key now:");
-        let key: <Shift as Cipher>::Key = process_input(|| {
+        let key: <ShiftCipher as Cipher>::Key = process_input(|| {
             println!("{KEY_PROMPT}");
         })?;
         match try_decrypt(ciphertxt, key) {
@@ -98,7 +98,7 @@ pub fn computer_chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>>
     let mut rng = thread_rng();
 
     loop {
-        let key = <Shift as Cipher>::Key::new(&mut rng);
+        let key = <ShiftCipher as Cipher>::Key::new(&mut rng);
         match try_decrypt(ciphertxt, key) {
             Ok(_) => break,
             Err(_) => continue, // TODO: How to handle different errors independently?
@@ -108,8 +108,8 @@ pub fn computer_chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>>
 }
 
 /// Decrypt with given key and ask whether to try again or not.
-pub fn try_decrypt(ciphertxt: &Ciphertext, key: <Shift as Cipher>::Key) -> Result<(), Box<dyn Error>> {
-    println!("\nYour computed plaintext is {}\n", Shift::decrypt(ciphertxt, &key));
+pub fn try_decrypt(ciphertxt: &Ciphertext, key: <ShiftCipher as Cipher>::Key) -> Result<(), Box<dyn Error>> {
+    println!("\nYour computed plaintext is {}\n", ShiftCipher::decrypt(ciphertxt, &key));
     println!("\nAre you happy with this decryption?");
     ConsentMenu::print_menu();
 

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -4,8 +4,8 @@ use crate::{
     menu::{ConsentMenu, DecryptMenu, Menu},
 };
 use classical_crypto::{
-    shift::{Message, Ciphertext, ShiftCipher},
-    Cipher, Key,
+    shift::{Ciphertext, Key, Message, ShiftCipher},
+    CipherTrait, KeyTrait,
 };
 use rand::thread_rng;
 use std::error::Error;
@@ -17,7 +17,7 @@ pub fn make_key() -> Result<(), Box<dyn Error>> {
 
     loop {
         // Generate a key
-        let key = <ShiftCipher as Cipher>::Key::new(&mut rng);
+        let key = Key::new(&mut rng);
 
         println!("\nWe generated your key successfully!.");
         println!("\nWe shouldn't export your key (or say, save it in logs), but we can!");
@@ -48,7 +48,7 @@ pub fn encrypt() -> Result<(), Box<dyn Error>> {
 
     println!("\nNow, do you have a key that was generated uniformly at random that you remember and \nwould like to use? If yes, please enter your key. Otherwise, please pick a fresh key \nuniformly at random from the ring of integers modulo 26 yourself. \n\nYou won't be as good at this as a computer, but if you understand the cryptosystem \nyou are using (something we cryptographers routinely assume about other people, while \npretending that we aren't assuming this), you will probably not pick a key of 0, \nwhich is equivalent to sending your messages \"in the clear\", i.e., unencrypted. Good \nluck! \n\nGo ahead and enter your key now:");
 
-    let key: <ShiftCipher as Cipher>::Key = process_input(|| {
+    let key: Key = process_input(|| {
         println!("{KEY_PROMPT}");
     })?;
 
@@ -85,7 +85,7 @@ pub fn decrypt(command: DecryptMenu) -> Result<(), Box<dyn Error>> {
 pub fn chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>> {
     loop {
         println!("\nOK. Please enter a key now:");
-        let key: <ShiftCipher as Cipher>::Key = process_input(|| {
+        let key: Key = process_input(|| {
             println!("{KEY_PROMPT}");
         })?;
         match try_decrypt(ciphertxt, key) {
@@ -101,7 +101,7 @@ pub fn computer_chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>>
     let mut rng = thread_rng();
 
     loop {
-        let key = <ShiftCipher as Cipher>::Key::new(&mut rng);
+        let key = Key::new(&mut rng);
         match try_decrypt(ciphertxt, key) {
             Ok(_) => break,
             Err(_) => continue, // TODO: How to handle different errors independently?
@@ -111,10 +111,7 @@ pub fn computer_chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>>
 }
 
 /// Decrypt with given key and ask whether to try again or not.
-pub fn try_decrypt(
-    ciphertxt: &Ciphertext,
-    key: <ShiftCipher as Cipher>::Key,
-) -> Result<(), Box<dyn Error>> {
+pub fn try_decrypt(ciphertxt: &Ciphertext, key: Key) -> Result<(), Box<dyn Error>> {
     println!(
         "\nYour computed plaintext is {}\n",
         ShiftCipher::decrypt(ciphertxt, &key)

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -3,7 +3,10 @@ use crate::{
     io_helper::process_input,
     menu::{ConsentMenu, DecryptMenu, Menu},
 };
-use classical_crypto::{Cipher, Key, ShiftCipher};
+use classical_crypto::{
+    shift::{Ciphertext, ShiftCipher},
+    Cipher, Key,
+};
 use rand::thread_rng;
 use std::error::Error;
 
@@ -60,7 +63,7 @@ pub fn encrypt() -> Result<(), Box<dyn Error>> {
 pub fn decrypt(command: DecryptMenu) -> Result<(), Box<dyn Error>> {
     println!("\nEnter your ciphertext. Ciphertexts use characters only from the Latin Alphabet:");
 
-    let ciphertxt: <ShiftCipher as Cipher>::Ciphertext = process_input(|| {
+    let ciphertxt: Ciphertext = process_input(|| {
         println!("\nCiphertext must contain characters from the Latin Alphabet only.");
     })?;
 
@@ -79,7 +82,7 @@ pub fn decrypt(command: DecryptMenu) -> Result<(), Box<dyn Error>> {
 }
 
 /// Gets key from stdin and attempts to decrypt.
-pub fn chosen_key(ciphertxt: &<ShiftCipher as Cipher>::Ciphertext) -> Result<(), Box<dyn Error>> {
+pub fn chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>> {
     loop {
         println!("\nOK. Please enter a key now:");
         let key: <ShiftCipher as Cipher>::Key = process_input(|| {
@@ -94,9 +97,7 @@ pub fn chosen_key(ciphertxt: &<ShiftCipher as Cipher>::Ciphertext) -> Result<(),
 }
 
 /// Has computer choose key uniformly at random and attempts to decrypt.
-pub fn computer_chosen_key(
-    ciphertxt: &<ShiftCipher as Cipher>::Ciphertext,
-) -> Result<(), Box<dyn Error>> {
+pub fn computer_chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>> {
     let mut rng = thread_rng();
 
     loop {
@@ -111,7 +112,7 @@ pub fn computer_chosen_key(
 
 /// Decrypt with given key and ask whether to try again or not.
 pub fn try_decrypt(
-    ciphertxt: &<ShiftCipher as Cipher>::Ciphertext,
+    ciphertxt: &Ciphertext,
     key: <ShiftCipher as Cipher>::Key,
 ) -> Result<(), Box<dyn Error>> {
     println!(

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -14,7 +14,7 @@ pub fn make_key() -> Result<(), Box<dyn Error>> {
 
     loop {
         // Generate a key
-        let key = Key::new(&mut rng);
+        let key = <Shift as Cipher>::Key::new(&mut rng);
 
         println!("\nWe generated your key successfully!.");
         println!("\nWe shouldn't export your key (or say, save it in logs), but we can!");
@@ -45,7 +45,7 @@ pub fn encrypt() -> Result<(), Box<dyn Error>> {
 
     println!("\nNow, do you have a key that was generated uniformly at random that you remember and \nwould like to use? If yes, please enter your key. Otherwise, please pick a fresh key \nuniformly at random from the ring of integers modulo 26 yourself. \n\nYou won't be as good at this as a computer, but if you understand the cryptosystem \nyou are using (something we cryptographers routinely assume about other people, while \npretending that we aren't assuming this), you will probably not pick a key of 0, \nwhich is equivalent to sending your messages \"in the clear\", i.e., unencrypted. Good \nluck! \n\nGo ahead and enter your key now:");
 
-    let key: Key = process_input(|| {
+    let key: <Shift as Cipher>::Key = process_input(|| {
         println!("{KEY_PROMPT}");
     })?;
 
@@ -82,7 +82,7 @@ pub fn decrypt(command: DecryptMenu) -> Result<(), Box<dyn Error>> {
 pub fn chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>> {
     loop {
         println!("\nOK. Please enter a key now:");
-        let key: Key = process_input(|| {
+        let key: <Shift as Cipher>::Key = process_input(|| {
             println!("{KEY_PROMPT}");
         })?;
         match try_decrypt(ciphertxt, key) {
@@ -98,7 +98,7 @@ pub fn computer_chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>>
     let mut rng = thread_rng();
 
     loop {
-        let key = Key::new(&mut rng);
+        let key = <Shift as Cipher>::Key::new(&mut rng);
         match try_decrypt(ciphertxt, key) {
             Ok(_) => break,
             Err(_) => continue, // TODO: How to handle different errors independently?
@@ -108,7 +108,7 @@ pub fn computer_chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>>
 }
 
 /// Decrypt with given key and ask whether to try again or not.
-pub fn try_decrypt(ciphertxt: &Ciphertext, key: Key) -> Result<(), Box<dyn Error>> {
+pub fn try_decrypt(ciphertxt: &Ciphertext, key: <Shift as Cipher>::Key) -> Result<(), Box<dyn Error>> {
     println!("\nYour computed plaintext is {}\n", Shift::decrypt(ciphertxt, &key));
     println!("\nAre you happy with this decryption?");
     ConsentMenu::print_menu();

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -3,7 +3,7 @@ use crate::{
     io_helper::process_input,
     menu::{ConsentMenu, DecryptMenu, Menu},
 };
-use classical_crypto::{CipherText, Key, Message};
+use classical_crypto::{shift::Shift, Cipher, Ciphertext, Key, Message};
 use rand::thread_rng;
 use std::error::Error;
 
@@ -49,7 +49,7 @@ pub fn encrypt() -> Result<(), Box<dyn Error>> {
         println!("{KEY_PROMPT}");
     })?;
 
-    println!("\nYour ciphertext is {}", msg.encrypt(&key));
+    println!("\nYour ciphertext is {}", Shift::encrypt(&msg, &key));
     println!("\nLook for patterns in your ciphertext. Could you definitively figure out the key and \noriginal plaintext message if you didn't already know it?");
 
     Ok(())
@@ -60,7 +60,7 @@ pub fn encrypt() -> Result<(), Box<dyn Error>> {
 pub fn decrypt(command: DecryptMenu) -> Result<(), Box<dyn Error>> {
     println!("\nEnter your ciphertext. Ciphertexts use characters only from the Latin Alphabet:");
 
-    let ciphertxt: CipherText = process_input(|| {
+    let ciphertxt: Ciphertext = process_input(|| {
         println!("\nCiphertext must contain characters from the Latin Alphabet only.");
     })?;
 
@@ -79,7 +79,7 @@ pub fn decrypt(command: DecryptMenu) -> Result<(), Box<dyn Error>> {
 }
 
 /// Gets key from stdin and attempts to decrypt.
-pub fn chosen_key(ciphertxt: &CipherText) -> Result<(), Box<dyn Error>> {
+pub fn chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>> {
     loop {
         println!("\nOK. Please enter a key now:");
         let key: Key = process_input(|| {
@@ -94,7 +94,7 @@ pub fn chosen_key(ciphertxt: &CipherText) -> Result<(), Box<dyn Error>> {
 }
 
 /// Has computer choose key uniformly at random and attempts to decrypt.
-pub fn computer_chosen_key(ciphertxt: &CipherText) -> Result<(), Box<dyn Error>> {
+pub fn computer_chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>> {
     let mut rng = thread_rng();
 
     loop {
@@ -108,8 +108,8 @@ pub fn computer_chosen_key(ciphertxt: &CipherText) -> Result<(), Box<dyn Error>>
 }
 
 /// Decrypt with given key and ask whether to try again or not.
-pub fn try_decrypt(ciphertxt: &CipherText, key: Key) -> Result<(), Box<dyn Error>> {
-    println!("\nYour computed plaintext is {}\n", ciphertxt.decrypt(&key));
+pub fn try_decrypt(ciphertxt: &Ciphertext, key: Key) -> Result<(), Box<dyn Error>> {
+    println!("\nYour computed plaintext is {}\n", Shift::decrypt(ciphertxt, &key));
     println!("\nAre you happy with this decryption?");
     ConsentMenu::print_menu();
 

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -3,7 +3,7 @@ use crate::{
     io_helper::process_input,
     menu::{ConsentMenu, DecryptMenu, Menu},
 };
-use classical_crypto::{ShiftCipher, Cipher, Key, Ciphertext, Message};
+use classical_crypto::{Cipher, Ciphertext, Key, Message, ShiftCipher};
 use rand::thread_rng;
 use std::error::Error;
 
@@ -108,8 +108,14 @@ pub fn computer_chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>>
 }
 
 /// Decrypt with given key and ask whether to try again or not.
-pub fn try_decrypt(ciphertxt: &Ciphertext, key: <ShiftCipher as Cipher>::Key) -> Result<(), Box<dyn Error>> {
-    println!("\nYour computed plaintext is {}\n", ShiftCipher::decrypt(ciphertxt, &key));
+pub fn try_decrypt(
+    ciphertxt: &Ciphertext,
+    key: <ShiftCipher as Cipher>::Key,
+) -> Result<(), Box<dyn Error>> {
+    println!(
+        "\nYour computed plaintext is {}\n",
+        ShiftCipher::decrypt(ciphertxt, &key)
+    );
     println!("\nAre you happy with this decryption?");
     ConsentMenu::print_menu();
 

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -49,7 +49,7 @@ pub fn encrypt() -> Result<(), Box<dyn Error>> {
         println!("{KEY_PROMPT}");
     })?;
 
-    println!("\nYour ciphertext is {}", *ShiftCipher::encrypt(&msg, &key));
+    println!("\nYour ciphertext is {}", ShiftCipher::encrypt(&msg, &key));
     println!("\nLook for patterns in your ciphertext. Could you definitively figure out the key and \noriginal plaintext message if you didn't already know it?");
 
     Ok(())


### PR DESCRIPTION
This refactor provides:
* A Cipher trait with encryption & decryption functionality.
* A Key trait with key generation functionality.
* An updated implementation of the Latin Shift Cipher that uses wrapper types to tightly couple the Shift cipher to its message, ciphertext, and key spaces, while still allowing reuse of the (now private) inner types for other ciphers.
* Update docs and demo to showcase desired usage, which is hopefully reasonable ergonomic while also preventing misuse.