### PR TITLE
Clean up error handling, part one

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,5 +1,5 @@
-# This is a makefile that can be run using `cargo make`. 
-# See https://sagiegurari.github.io/cargo-make/ for documentation. 
+# This is a makefile that can be# See https://sagiegurari.github.io/cargo-make/ for documentation. 
+# run using `cargo make`. 
 # There is a lot more functionality than what is used here, including 
 # testing multiple platforms, running benchmarks, security checks, etc.
 
@@ -18,14 +18,10 @@ args = ["clippy", "--all-targets", "--workspace"]
 [tasks.build]
 dependencies = ["clean"]
 
-# Since examples are not specifed as test code, you have to pass
-# the option "--examples" to make sure that the dev flow builds
-# and runs all the associated examples for the crate. This helps
-# catch problems early that might otherwise impact projects
-# dependent on the library.
-[tasks.examples]
+# Make sure every to test everything
+[tasks.test]
 command = "cargo"
-args = ["test", "--examples", "--workspace"]
+args = ["test", "--workspace", "--all-targets"]
 
 # Potentially useful options to add include:
 # - "--document-private-items", since this is a tutorial-style library.
@@ -74,6 +70,5 @@ dependencies = [
     "clippy", 
     "build",
     "test",
-    "examples",
 ]
 

--- a/classical_crypto/Cargo.toml
+++ b/classical_crypto/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 rand = "0.8"
+thiserror = "1"
 
 [dev-dependencies]
 rand_chacha = "0.3.1"

--- a/classical_crypto/src/errors.rs
+++ b/classical_crypto/src/errors.rs
@@ -1,0 +1,45 @@
+//! Contains custom error types.
+use thiserror::Error;
+
+/// An opaque error type that hides the implementation details of internal
+/// errors.
+// This is a technique that is easy to use with the `thiserror` crate. The attribute `error(transparent)` forwards the source and display methods straight through to the underlying internal error representations.
+#[derive(Error, Debug, PartialEq)]
+#[error(transparent)]
+pub struct InternalError(#[from] ErrorRepr);
+
+/// Internal errors.
+#[derive(Clone, Debug, PartialEq, Error)]
+pub(crate) enum ErrorRepr {
+    /// Thrown when a conversion between the Latin
+    /// Alphabet and the ring of integers modulo [`RingElement::MODULUS`] fails.
+    ///
+    /// This error should only be thrown if:
+    /// - There is a mistake in the definition of the constant
+    ///   [`RingElement::ALPH_ENCODING`];
+    /// - The input was not a lowercase letter from the Latin Alphabet.
+    #[error("Failed to encode the following characters as ring elements: {0}")]
+    RingElementEncodingError(String),
+}
+
+// TODO: Are these usable for other ciphers?
+/// An error type that indicates a failure to parse a string.
+#[derive(Debug, PartialEq, thiserror::Error)]
+pub enum EncodingError {
+    /// Error thrown when parsing a string as a message. This error is thrown when the string included one or more characters that are not
+    /// lowercase letters from the Latin Alphabet.
+    #[error("Invalid Message. {0}")]
+    InvalidMessage(InternalError),
+    /// Error thrown when parsing a string as a ciphertext. This error is thrown when the string included one or more characters that are not
+    /// letters from the Latin Alphabet. We allow for strings containing both
+    /// capitalized and lowercase letters when parsing as string as a
+    /// ciphertext.
+    #[error("Invalid Ciphertext. {0}")]
+    InvalidCiphertext(InternalError),
+    /// Error thrown when parsing a string as a key. This error is thrown when the string does not represent a number in the appropriate
+    /// range. e.g., for the Latin Shift Cipher, keys are in the range 0 to 25,
+    /// inclusive.
+    // TODO: Add error context
+    #[error("Input does not represent a valid key.")]
+    InvalidKey,
+}

--- a/classical_crypto/src/errors.rs
+++ b/classical_crypto/src/errors.rs
@@ -12,7 +12,7 @@ pub struct InternalError(#[from] ErrorRepr);
 
 /// Internal errors.
 #[derive(Clone, Debug, PartialEq, Error)]
-pub(crate) enum ErrorRepr {
+pub(super) enum ErrorRepr {
     /// Thrown when a conversion between the Latin
     /// Alphabet and the ring of integers modulo [`RingElement::MODULUS`] fails.
     ///

--- a/classical_crypto/src/errors.rs
+++ b/classical_crypto/src/errors.rs
@@ -3,7 +3,9 @@ use thiserror::Error;
 
 /// An opaque error type that hides the implementation details of internal
 /// errors.
-// This is a technique that is easy to use with the `thiserror` crate. The attribute `error(transparent)` forwards the source and display methods straight through to the underlying internal error representations.
+// This is a technique that is easy to use with the `thiserror` crate. The attribute
+// `error(transparent)` forwards the source and display methods straight through to the underlying
+// internal error representations.
 #[derive(Error, Debug, PartialEq)]
 #[error(transparent)]
 pub struct InternalError(#[from] ErrorRepr);
@@ -26,20 +28,22 @@ pub(crate) enum ErrorRepr {
 /// An error type that indicates a failure to parse a string.
 #[derive(Debug, PartialEq, thiserror::Error)]
 pub enum EncodingError {
-    /// Error thrown when parsing a string as a message. This error is thrown when the string included one or more characters that are not
+    /// Error thrown when parsing a string as a message. This error is thrown
+    /// when the string included one or more characters that are not
     /// lowercase letters from the Latin Alphabet.
     #[error("Invalid Message. {0}")]
     InvalidMessage(InternalError),
-    /// Error thrown when parsing a string as a ciphertext. This error is thrown when the string included one or more characters that are not
-    /// letters from the Latin Alphabet. We allow for strings containing both
+    /// Error thrown when parsing a string as a ciphertext. This error is thrown
+    /// when the string included one or more characters that are not letters
+    /// from the Latin Alphabet. We allow for strings containing both
     /// capitalized and lowercase letters when parsing as string as a
     /// ciphertext.
     #[error("Invalid Ciphertext. {0}")]
     InvalidCiphertext(InternalError),
-    /// Error thrown when parsing a string as a key. This error is thrown when the string does not represent a number in the appropriate
+    /// Error thrown when parsing a string as a key. This error is thrown when
+    /// the string does not represent a number in the appropriate
     /// range. e.g., for the Latin Shift Cipher, keys are in the range 0 to 25,
     /// inclusive.
-    // TODO: Add error context
-    #[error("Input does not represent a valid key.")]
-    InvalidKey,
+    #[error("Input \"{0}\" does not represent a valid key")]
+    InvalidKey(String),
 }

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -114,11 +114,11 @@ struct RingElement(i8);
 ///   [`RingElement::ALPH_ENCODING`];
 /// - The input was not a lowercase letter from the Latin Alphabet.
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
-struct RingElementEncodingError;
+struct RingElementEncodingError(char);
 
 impl fmt::Display for RingElementEncodingError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Failed to encode char as ring element")
+        write!(f, "Failed to encode char {} as ring element", self.0)
     }
 }
 
@@ -201,7 +201,7 @@ impl AlphabetEncoding for RingElement {
         RingElement::ALPH_ENCODING
             .into_iter()
             .find_map(|(x, y)| if x == ltr { Some(RingElement(y)) } else { None })
-            .ok_or(RingElementEncodingError)
+            .ok_or(RingElementEncodingError(ltr))
     }
 
     /// Convert from a ring element to a character.
@@ -353,7 +353,7 @@ impl FromStr for Message {
             .partition(Result::is_ok);
 
         if !errors.is_empty() {
-            return Err(EncodingError::InvalidMessage)
+            return Err(EncodingError::InvalidMessage);
         }
         msg.into_iter().collect()
     }
@@ -501,8 +501,14 @@ mod tests {
 
     #[test]
     fn ring_elmt_encoding_error() {
-        assert_eq!(RingElement::from_char('_'), Err(RingElementEncodingError));
-        assert_eq!(RingElement::from_char('A'), Err(RingElementEncodingError));
+        assert_eq!(
+            RingElement::from_char('_'),
+            Err(RingElementEncodingError('_'))
+        );
+        assert_eq!(
+            RingElement::from_char('A'),
+            Err(RingElementEncodingError('A'))
+        );
     }
 
     #[test]

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -312,6 +312,7 @@ impl fmt::Display for RingElement {
     }
 }
 
+/// This is a bit strange, since we are only reading single chars from the lowercase Latin Alphabet, whereas one might expect to be able to read "25" from a string into RingElement here.
 impl FromStr for RingElement {
     type Err = RingElementEncodingError;
 

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -355,6 +355,7 @@ impl FromStr for Message {
         if !errors.is_empty() {
             return Err(EncodingError::InvalidMessage);
         }
+
         msg.into_iter().collect()
     }
 }
@@ -370,13 +371,7 @@ impl fmt::Display for Message {
 // Ciphertext?
 impl FromIterator<RingElement> for Message {
     fn from_iter<I: IntoIterator<Item = RingElement>>(iter: I) -> Self {
-        let mut c = Vec::new();
-
-        for i in iter {
-            c.push(i);
-        }
-
-        Message(c)
+        Message(iter.into_iter().collect())
     }
 }
 
@@ -412,13 +407,7 @@ impl fmt::Display for Ciphertext {
 
 impl FromIterator<RingElement> for Ciphertext {
     fn from_iter<I: IntoIterator<Item = RingElement>>(iter: I) -> Self {
-        let mut c = Vec::new();
-
-        for i in iter {
-            c.push(i);
-        }
-
-        Ciphertext(c)
+        Ciphertext(iter.into_iter().collect())
     }
 }
 

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -312,18 +312,6 @@ impl fmt::Display for RingElement {
     }
 }
 
-/// This is a bit strange, since we are only reading single chars from the lowercase Latin Alphabet, whereas one might expect to be able to read "25" from a string into RingElement here.
-impl FromStr for RingElement {
-    type Err = RingElementEncodingError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.parse::<char>() {
-            Ok(c) => RingElement::from_char(c),
-            Err(e) => Err(RingElementEncodingError::ParseFailure(e)),
-        }
-    }
-}
-
 /// A plaintext of arbitrary length.
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 struct Message(Vec<RingElement>);
@@ -547,20 +535,6 @@ mod tests {
             RingElement::from_char('A'),
             Err(RingElementEncodingError::InvalidChar('A'))
         );
-
-        let err0 = RingElement::from_str("ab").unwrap_err();
-        assert_eq!(
-            err0.to_string(),
-            "Failed to encode ring element: too many characters in string"
-        );
-        assert!(matches!(err0, RingElementEncodingError::ParseFailure(..)));
-
-        let err1 = RingElement::from_str("").unwrap_err();
-        assert_eq!(
-            err1.to_string(),
-            "Failed to encode ring element: cannot parse char from empty string"
-        );
-        assert!(matches!(err1, RingElementEncodingError::ParseFailure(..)))
     }
 
     #[test]

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -116,6 +116,14 @@ struct RingElement(i8);
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
 struct RingElementEncodingError;
 
+impl fmt::Display for RingElementEncodingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Failed to encode char as ring element")
+    }
+}
+
+impl std::error::Error for RingElementEncodingError {}
+
 impl RingElement {
     /// The default alphabet encoding for the Latin Shift Cipher.
     const ALPH_ENCODING: [(char, i8); 26] = [
@@ -317,15 +325,17 @@ impl fmt::Display for EncodingError {
         match *self {
             EncodingError::InvalidMessage => write!(
                 f,
-                "Please forgive our awkward API decision and use only lowercase characters from the Latin alphabet"
+                "Forgive our awkward API decision; use only lowercase characters from the Latin alphabet"
             ),
             EncodingError::InvalidCiphertext => {
-                write!(f, "Please forgive our awkward API decision and use only characters from the Latin alphabet")
+                write!(f, "Forgive our awkward API decision; use only characters from the Latin alphabet")
             }
-            EncodingError::InvalidKey => write!(f, "The string does not represent a valid key"),
+            EncodingError::InvalidKey => write!(f, "Input does not represent a valid key"),
         }
     }
 }
+
+impl std::error::Error for EncodingError {}
 
 /// Parse a message from a string.
 ///
@@ -494,6 +504,10 @@ mod tests {
         expected = "Could not map to `char`: The definition of `RingElement::ALPH_ENCODING` must have an error or there is an invalid `RingElement`."
     )]
     fn ring_elmt_encoding_panic() {
+        // Sometimes you google to find out how to prevent things like backtraces
+        // appearing in your output for tests that should panic
+        let f = |_: &std::panic::PanicInfo| {};
+        std::panic::set_hook(Box::new(f));
         let _fail = RingElement(26).to_char();
     }
 

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -39,9 +39,7 @@ use std::{
 pub mod errors;
 pub mod shift;
 
-pub use crate::errors::{EncodingError, InternalError};
-
-use crate::errors::ErrorRepr;
+use crate::errors::{EncodingError, ErrorRepr};
 
 /// This trait represents a deterministic cipher.
 pub trait CipherTrait {

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -317,10 +317,10 @@ impl fmt::Display for EncodingError {
         match *self {
             EncodingError::InvalidMessage => write!(
                 f,
-                "Please use lowercase characters from the Latin alphabet only"
+                "Please forgive our awkward API decision and use only lowercase characters from the Latin alphabet"
             ),
             EncodingError::InvalidCiphertext => {
-                write!(f, "Please use characters from the Latin alphabet only")
+                write!(f, "Please forgive our awkward API decision and use only characters from the Latin alphabet")
             }
             EncodingError::InvalidKey => write!(f, "The string does not represent a valid key"),
         }

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -31,7 +31,6 @@
 
 use rand::{CryptoRng, Rng};
 use std::{
-    char::ParseCharError,
     fmt,
     ops::{Add, Sub},
     str::FromStr,
@@ -117,7 +116,6 @@ struct RingElement(i8);
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum RingElementEncodingError {
     InvalidChar(char),
-    ParseFailure(ParseCharError),
 }
 
 impl fmt::Display for RingElementEncodingError {
@@ -126,25 +124,7 @@ impl fmt::Display for RingElementEncodingError {
             RingElementEncodingError::InvalidChar(c) => {
                 write!(f, "Failed to encode char {} as ring element", c)
             }
-            RingElementEncodingError::ParseFailure(e) => {
-                write!(f, "Failed to encode ring element: { }", e)
-            }
         }
-    }
-}
-
-impl std::error::Error for RingElementEncodingError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match *self {
-            RingElementEncodingError::InvalidChar(_) => None,
-            RingElementEncodingError::ParseFailure(ref e) => Some(e),
-        }
-    }
-}
-
-impl From<ParseCharError> for RingElementEncodingError {
-    fn from(err: ParseCharError) -> Self {
-        RingElementEncodingError::ParseFailure(err)
     }
 }
 

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -387,7 +387,8 @@ impl FromStr for Message {
             .map(|i| RingElement::from_char(i).or(Err(EncodingError::InvalidMessage)))
             .partition(Result::is_ok);
 
-        if !errors.is_empty() {
+        // Return high level error if msg is empty or s contained invalid chars
+        if !errors.is_empty()||msg.is_empty() {
             return Err(EncodingError::InvalidMessage);
         }
 
@@ -589,6 +590,10 @@ mod tests {
     fn msg_encoding_error() {
         assert_eq!(
             Message::new("we will meet at midnight;"),
+            Err(EncodingError::InvalidMessage)
+        );
+        assert_eq!(
+            Message::new(""),
             Err(EncodingError::InvalidMessage)
         )
     }

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -167,7 +167,7 @@ impl AlphabetEncoding for RingElement {
     /// Convert from a character.
     ///
     /// # Errors
-    /// This method will return a custom pub(crate) error if the constant
+    /// This method will return a custom internal error if the constant
     /// [`RingElement::ALPH_ENCODING`] does not specify a mapping to the ring of
     /// integers for the given input. This happens if the input is not from the
     /// lowercase Latin Alphabet. For crate users, this error type will get

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -49,21 +49,11 @@ pub trait CipherTrait {
     /// The keyspace of the cipher, which must implement the [`KeyTrait`] trait.
     type Key: KeyTrait;
 
-    // TODO: not implemented yet
-    /// The error type returned by [`CipherTrait::encrypt`].
-    type EncryptionError;
-
-    // TODO: not implemented yet
-    /// The error type returned by [`CipherTrait::decrypt`].
-    type DecryptionError;
-
-    // TODO: Return a Result instead
     /// The encryption function of the cipher.
     /// Invariant: For each key `k` in the keyspace, we have decrypt(encrypt(m,
     /// k), k) = m for every message `m` in the message space.
     fn encrypt(msg: &Self::Message, key: &Self::Key) -> Self::Ciphertext;
 
-    // TODO: Return a Result instead
     /// The decryption function of the cipher.
     /// Invariant: For each key `k` in the keyspace, we have decrypt(encrypt(m,
     /// k), k) = m for every message `m` in the message space.
@@ -333,7 +323,7 @@ impl fmt::Display for EncodingError {
             EncodingError::InvalidCiphertext => {
                 write!(
                     f,
-                    "Forgive our awkward API decision; use only characters from the Latin alphabet"
+                    "Awkward API: use only characters from the Latin alphabet"
                 )
             }
             EncodingError::InvalidKey => write!(f, "Input does not represent a valid key"),
@@ -343,14 +333,15 @@ impl fmt::Display for EncodingError {
 
 impl RingElementEncodingError {
     fn describe(errors: Vec<RingElementEncodingError>) -> String {
-        let mut description: String = "Forgive our awkward API decision; use only lowercase characters from the Latin alphabet.".to_string();
+        let mut description: String =
+            "Awkward API: use only lowercase characters from the Latin alphabet. ".to_string();
 
         if errors.is_empty() {
             description = "Empty string not allowed".to_string();
             return description;
         }
 
-        description.push_str("\nInvalid characters used: ");
+        description.push_str("Invalid characters used: ");
 
         for err in errors.into_iter() {
             let RingElementEncodingError::InvalidChar(char) = err;
@@ -406,8 +397,7 @@ impl fmt::Display for Message {
         write!(f, "{txt}")
     }
 }
-// Question: Can I do something generic here that covers both Message and
-// Ciphertext?
+
 impl FromIterator<RingElement> for Message {
     fn from_iter<I: IntoIterator<Item = RingElement>>(iter: I) -> Self {
         Message(iter.into_iter().collect())

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -347,9 +347,15 @@ impl FromStr for Message {
     type Err = EncodingError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        s.chars()
+        let (msg, errors): (Vec<_>, Vec<_>) = s
+            .chars()
             .map(|i| RingElement::from_char(i).or(Err(EncodingError::InvalidMessage)))
-            .collect()
+            .partition(Result::is_ok);
+
+        if !errors.is_empty() {
+            return Err(EncodingError::InvalidMessage)
+        }
+        msg.into_iter().collect()
     }
 }
 
@@ -538,7 +544,7 @@ mod tests {
     // Malformed message errors.
     fn msg_encoding_error() {
         assert_eq!(
-            Message::new("we will meet at midnight"),
+            Message::new("we will meet at midnight;"),
             Err(EncodingError::InvalidMessage)
         )
     }

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -145,12 +145,12 @@ impl FromStr for Key {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let key = match i8::from_str(s) {
             Ok(num) => num,
-            Err(_) => return Err(EncodingError::InvalidKey),
+            Err(_) => return Err(EncodingError::InvalidKey(s.to_string())),
         };
 
         match key {
             x if (0..=25).contains(&x) => Ok(Key::from(RingElement::from_i8(key))),
-            _ => Err(EncodingError::InvalidKey),
+            _ => Err(EncodingError::InvalidKey(s.to_string())),
         }
     }
 }
@@ -424,5 +424,33 @@ mod tests {
             ShiftCipher::decrypt(&ShiftCipher::encrypt(&msg1, &key1), &key2),
             msg1
         )
+    }
+
+    #[test]
+    fn new_key_err() {
+        assert_eq!(
+            Key::from_str("65").unwrap_err(),
+            EncodingError::InvalidKey("65".to_string())
+        );
+        assert_eq!(
+            Key::from_str("").unwrap_err(),
+            EncodingError::InvalidKey("".to_string())
+        );
+        assert_eq!(
+            Key::from_str("-5").unwrap_err(),
+            EncodingError::InvalidKey("-5".to_string())
+        );
+        assert_eq!(
+            Key::from_str("26").unwrap_err(),
+            EncodingError::InvalidKey("26".to_string())
+        );
+        assert_eq!(
+            Key::from_str("asdfas").unwrap_err(),
+            EncodingError::InvalidKey("asdfas".to_string())
+        );
+        assert_eq!(
+            Key::from_str("4s").unwrap_err(),
+            EncodingError::InvalidKey("4s".to_string())
+        );
     }
 }

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -10,8 +10,11 @@ use rand::{CryptoRng, Rng};
 use std::{fmt::Display, str::FromStr};
 
 /// The ciphertext space for the Latin Shift Cipher.
-// Notes: 
-// This is a wrapper type around the library's private  representation of a ciphertext using the ring of integers mod 26. We do this because we want to force library users to use types specific to the Latin Shift cipher when using the Latin Shift Cipher, even though other ciphers may also (mathematically and under the hood in the implementation) operate on the same underlying types
+// Notes:
+// This is a wrapper type around the library's private  representation of a ciphertext using the
+// ring of integers mod 26. We do this because we want to force library users to use types specific
+// to the Latin Shift cipher when using the Latin Shift Cipher, even though other ciphers may also
+// (mathematically and under the hood in the implementation) operate on the same underlying types
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Ciphertext(Ciphtxt);
 
@@ -35,8 +38,12 @@ impl FromIterator<RingElement> for Ciphertext {
 }
 
 /// The message space of the Latin Shift Cipher.
-// Notes: 
-// 1. This is a wrapper type around the library's private  representation of a ciphertext using the ring of integers mod 26. We do this because we want to force library users to use types specific to the Latin Shift cipher when using the Latin Shift Cipher, even though other ciphers may also (mathematically and under the hood in the implementation) operate on the same underlying types
+// Notes:
+// 1. This is a wrapper type around the library's private  representation of a ciphertext using the
+//    ring of integers mod 26. We do this because we want to force library users to use types
+//    specific to the Latin Shift cipher when using the Latin Shift Cipher, even though other
+//    ciphers may also (mathematically and under the hood in the implementation) operate on the same
+//    underlying types
 // 2. The Rust Book (19.3) offers guidance on using the `Deref` trait in the newtype pattern to automatically implement all methods defined on the inner type for the wrapper type. We do not do this because doing so makes for surprises in the API. Also note that this trick does not give you trait implementations defined on the inner type for the wrapper. See also discussion [`here`](https://rust-unofficial.github.io/patterns/anti_patterns/deref.html)
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Message(Msg);

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -337,6 +337,15 @@ mod tests {
         )
     }
 
+    #[test]
+    fn unchecked_dec_panic(){
+        let ciph = Ciphertext(Ciphtxt(vec!(RingElement(65))));
+
+        let key = Key(RingElement(0));
+        println!("{}", ShiftCipher::decrypt(&ciph, &key));
+
+    }
+
     // Tests with randomly generated keys.
     #[test]
     fn enc_dec_random_keys() {

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -138,12 +138,12 @@ impl FromStr for Key {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let key = match i8::from_str(s) {
             Ok(num) => num,
-            Err(_) => return Err(EncodingError),
+            Err(_) => return Err(EncodingError::InvalidKey),
         };
 
         match key {
             x if (0..=25).contains(&x) => Ok(Key::from(RingElement::from_i8(key))),
-            _ => Err(EncodingError),
+            _ => Err(EncodingError::InvalidKey),
         }
     }
 }
@@ -339,21 +339,24 @@ mod tests {
 
     #[test]
     #[should_panic] // Panics because the library developer constructed an invalid RingElement
-    fn unchecked_dec_panic(){
-        let ciph = Ciphertext(Ciphtxt(vec!(RingElement(65))));
+    fn unchecked_dec_panic() {
+        let ciph = Ciphertext(Ciphtxt(vec![RingElement(65)]));
 
         let key = Key(RingElement(0));
         println!("{}", ShiftCipher::decrypt(&ciph, &key));
-
     }
 
     #[test]
-    // Won't panic because appropriate constructor used for RingElement, but result may surprise the library developer
-    fn unchecked_dec_nopanic(){
-        let ciph = Ciphertext(Ciphtxt(vec!(RingElement::from_i8(65))));
+    // Won't panic because appropriate constructor used for RingElement, but result
+    // may surprise the library developer
+    fn unchecked_dec_nopanic() {
+        let ciph = Ciphertext(Ciphtxt(vec![RingElement::from_i8(65)]));
 
         let key = Key(RingElement(0));
-        assert_eq!(ShiftCipher::decrypt(&ciph, &key), Message::from_str("n").expect("Test writer should ensure this example does not panic"));
+        assert_eq!(
+            ShiftCipher::decrypt(&ciph, &key),
+            Message::from_str("n").expect("Test writer should ensure this example does not panic")
+        );
     }
 
     // Tests with randomly generated keys.

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -338,6 +338,7 @@ mod tests {
     }
 
     #[test]
+    #[should_panic] // Panics because the library developer constructed an invalid RingElement
     fn unchecked_dec_panic(){
         let ciph = Ciphertext(Ciphtxt(vec!(RingElement(65))));
 

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -347,6 +347,15 @@ mod tests {
 
     }
 
+    #[test]
+    // Won't panic because appropriate constructor used for RingElement, but result may surprise the library developer
+    fn unchecked_dec_nopanic(){
+        let ciph = Ciphertext(Ciphtxt(vec!(RingElement::from_i8(65))));
+
+        let key = Key(RingElement(0));
+        assert_eq!(ShiftCipher::decrypt(&ciph, &key), Message::from_str("n").expect("Test writer should ensure this example does not panic"));
+    }
+
     // Tests with randomly generated keys.
     #[test]
     fn enc_dec_random_keys() {

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -164,9 +164,6 @@ impl CipherTrait for ShiftCipher {
     type Ciphertext = Ciphertext;
     type Key = Key;
 
-    type EncryptionError = EncryptionError;
-    type DecryptionError = DecryptionError;
-
     /// Encrypt a message.
     ///
     /// # Examples

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -338,8 +338,14 @@ mod tests {
     }
 
     #[test]
-    #[should_panic] // Panics because the library developer constructed an invalid RingElement
+    #[should_panic(
+        expected = "Could not map to `char`: The definition of `RingElement::ALPH_ENCODING` must have an error or there is an invalid `RingElement`."
+    )]
     fn unchecked_dec_panic() {
+        // Sometimes you google to find out how to prevent things like backtraces
+        // appearing in your output for tests that should panic
+        let f = |_: &std::panic::PanicInfo| {};
+        std::panic::set_hook(Box::new(f));
         let ciph = Ciphertext(Ciphtxt(vec![RingElement(65)]));
 
         let key = Key(RingElement(0));

--- a/classical_crypto/tests/integration_test.rs
+++ b/classical_crypto/tests/integration_test.rs
@@ -2,7 +2,7 @@
 //! not be entirely sensible as integration tests.
 use classical_crypto::{
     shift::{Ciphertext, Key, Message, ShiftCipher},
-    CipherTrait, EncodingError, KeyTrait
+    CipherTrait, EncodingError, KeyTrait,
 };
 use rand::thread_rng;
 use std::str::FromStr;
@@ -93,42 +93,30 @@ fn short_msg_example() {
 #[test]
 fn new_msg_err() {
     assert_eq!(
-        Message::new("this;crazy;world").unwrap_err(),
-        EncodingError::InvalidMessage("Awkward API: use only lowercase characters from the Latin alphabet. Invalid characters used: ; ; ".to_string()));
+        Message::new("this;crazy;world").unwrap_err().to_string(),
+        "Invalid Message. Failed to encode the following characters as ring elements: ;;"
+    );
 }
 
 #[test]
 fn new_ciphtxt_err() {
     assert_eq!(
-        Ciphertext::from_str("this;crazy;world").unwrap_err(),
-        EncodingError::InvalidCiphertext
+        Ciphertext::from_str("this;crazy;world")
+            .unwrap_err()
+            .to_string(),
+        "Invalid Ciphertext. Failed to encode the following characters as ring elements: ;;"
     )
 }
 
 #[test]
-fn new_key_err(){
-    assert_eq!(
-        Key::from_str("65").unwrap_err(),
-        EncodingError::InvalidKey
-    );
-    assert_eq!(
-        Key::from_str("").unwrap_err(),
-        EncodingError::InvalidKey
-    );
-    assert_eq!(
-        Key::from_str("-5").unwrap_err(),
-        EncodingError::InvalidKey
-    );
-    assert_eq!(
-        Key::from_str("26").unwrap_err(),
-        EncodingError::InvalidKey
-    );
+fn new_key_err() {
+    assert_eq!(Key::from_str("65").unwrap_err(), EncodingError::InvalidKey);
+    assert_eq!(Key::from_str("").unwrap_err(), EncodingError::InvalidKey);
+    assert_eq!(Key::from_str("-5").unwrap_err(), EncodingError::InvalidKey);
+    assert_eq!(Key::from_str("26").unwrap_err(), EncodingError::InvalidKey);
     assert_eq!(
         Key::from_str("asdfas").unwrap_err(),
         EncodingError::InvalidKey
     );
-    assert_eq!(
-        Key::from_str("4s").unwrap_err(),
-        EncodingError::InvalidKey
-    );
+    assert_eq!(Key::from_str("4s").unwrap_err(), EncodingError::InvalidKey);
 }

--- a/classical_crypto/tests/integration_test.rs
+++ b/classical_crypto/tests/integration_test.rs
@@ -2,7 +2,7 @@
 //! not be entirely sensible as integration tests.
 use classical_crypto::{
     shift::{Ciphertext, Key, Message, ShiftCipher},
-    CipherTrait, KeyTrait,
+    CipherTrait, EncodingError, KeyTrait
 };
 use rand::thread_rng;
 use std::str::FromStr;
@@ -87,5 +87,48 @@ fn short_msg_example() {
     assert_eq!(
         ShiftCipher::decrypt(&small_ciphertext, &fixed_key_1),
         small_msg_1
+    );
+}
+
+#[test]
+fn new_msg_err() {
+    assert_eq!(
+        Message::new("this;crazy;world").unwrap_err(),
+        EncodingError::InvalidMessage("Awkward API: use only lowercase characters from the Latin alphabet. Invalid characters used: ; ; ".to_string()));
+}
+
+#[test]
+fn new_ciphtxt_err() {
+    assert_eq!(
+        Ciphertext::from_str("this;crazy;world").unwrap_err(),
+        EncodingError::InvalidCiphertext
+    )
+}
+
+#[test]
+fn new_key_err(){
+    assert_eq!(
+        Key::from_str("65").unwrap_err(),
+        EncodingError::InvalidKey
+    );
+    assert_eq!(
+        Key::from_str("").unwrap_err(),
+        EncodingError::InvalidKey
+    );
+    assert_eq!(
+        Key::from_str("-5").unwrap_err(),
+        EncodingError::InvalidKey
+    );
+    assert_eq!(
+        Key::from_str("26").unwrap_err(),
+        EncodingError::InvalidKey
+    );
+    assert_eq!(
+        Key::from_str("asdfas").unwrap_err(),
+        EncodingError::InvalidKey
+    );
+    assert_eq!(
+        Key::from_str("4s").unwrap_err(),
+        EncodingError::InvalidKey
     );
 }

--- a/classical_crypto/tests/integration_test.rs
+++ b/classical_crypto/tests/integration_test.rs
@@ -2,7 +2,7 @@
 //! not be entirely sensible as integration tests.
 use classical_crypto::{
     shift::{Ciphertext, Key, Message, ShiftCipher},
-    CipherTrait, EncodingError, KeyTrait,
+    CipherTrait, KeyTrait,
 };
 use rand::thread_rng;
 use std::str::FromStr;
@@ -106,32 +106,4 @@ fn new_ciphtxt_err() {
             .to_string(),
         "Invalid Ciphertext. Failed to encode the following characters as ring elements: ;;"
     )
-}
-
-#[test]
-fn new_key_err() {
-    assert_eq!(
-        Key::from_str("65").unwrap_err(),
-        EncodingError::InvalidKey("65".to_string())
-    );
-    assert_eq!(
-        Key::from_str("").unwrap_err(),
-        EncodingError::InvalidKey("".to_string())
-    );
-    assert_eq!(
-        Key::from_str("-5").unwrap_err(),
-        EncodingError::InvalidKey("-5".to_string())
-    );
-    assert_eq!(
-        Key::from_str("26").unwrap_err(),
-        EncodingError::InvalidKey("26".to_string())
-    );
-    assert_eq!(
-        Key::from_str("asdfas").unwrap_err(),
-        EncodingError::InvalidKey("asdfas".to_string())
-    );
-    assert_eq!(
-        Key::from_str("4s").unwrap_err(),
-        EncodingError::InvalidKey("4s".to_string())
-    );
 }

--- a/classical_crypto/tests/integration_test.rs
+++ b/classical_crypto/tests/integration_test.rs
@@ -110,13 +110,28 @@ fn new_ciphtxt_err() {
 
 #[test]
 fn new_key_err() {
-    assert_eq!(Key::from_str("65").unwrap_err(), EncodingError::InvalidKey);
-    assert_eq!(Key::from_str("").unwrap_err(), EncodingError::InvalidKey);
-    assert_eq!(Key::from_str("-5").unwrap_err(), EncodingError::InvalidKey);
-    assert_eq!(Key::from_str("26").unwrap_err(), EncodingError::InvalidKey);
+    assert_eq!(
+        Key::from_str("65").unwrap_err(),
+        EncodingError::InvalidKey("65".to_string())
+    );
+    assert_eq!(
+        Key::from_str("").unwrap_err(),
+        EncodingError::InvalidKey("".to_string())
+    );
+    assert_eq!(
+        Key::from_str("-5").unwrap_err(),
+        EncodingError::InvalidKey("-5".to_string())
+    );
+    assert_eq!(
+        Key::from_str("26").unwrap_err(),
+        EncodingError::InvalidKey("26".to_string())
+    );
     assert_eq!(
         Key::from_str("asdfas").unwrap_err(),
-        EncodingError::InvalidKey
+        EncodingError::InvalidKey("asdfas".to_string())
     );
-    assert_eq!(Key::from_str("4s").unwrap_err(), EncodingError::InvalidKey);
+    assert_eq!(
+        Key::from_str("4s").unwrap_err(),
+        EncodingError::InvalidKey("4s".to_string())
+    );
 }

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -22,11 +22,11 @@ pub fn make_key() -> Result<(), Box<dyn Error>> {
         println!("\nWe generated your key successfully!.");
         println!("\nWe shouldn't export your key (or say, save it in logs), but we can!");
         println!("Here it is: {}\n", ShiftCipher::insecure_key_export(&key));
-                
+
         let command: ConsentMenu = process_input(|| {
             println!("\nAre you happy with your key?");
             ConsentMenu::print_menu()
-    })?;
+        })?;
 
         match command {
             ConsentMenu::NoKE => continue,
@@ -41,8 +41,8 @@ pub fn make_key() -> Result<(), Box<dyn Error>> {
 /// Takes in a key and a message and encrypts, then prints
 /// the result.
 pub fn encrypt() -> Result<(), Box<dyn Error>> {
-    
-    let msg: Message = process_input(|| println!("\nPlease enter the message you want to encrypt:"))?;
+    let msg: Message =
+        process_input(|| println!("\nPlease enter the message you want to encrypt:"))?;
 
     println!("\nNow, do you have a key that was generated uniformly at random that you remember and \nwould like to use? If yes, please enter your key. Otherwise, please pick a fresh key \nuniformly at random from the ring of integers modulo 26 yourself. \n\nYou won't be as good at this as a computer, but if you understand the cryptosystem \nyou are using (something we cryptographers routinely assume about other people, while \npretending that we aren't assuming this), you will probably not pick a key of 0, \nwhich is equivalent to sending your messages \"in the clear\", i.e., unencrypted. Good \nluck! \n");
 
@@ -57,7 +57,11 @@ pub fn encrypt() -> Result<(), Box<dyn Error>> {
 /// Takes in a ciphertext and attempts to decrypt and
 /// print result.
 pub fn decrypt(command: DecryptMenu) -> Result<(), Box<dyn Error>> {
-    let ciphertxt: Ciphertext = process_input(|| println!("\nEnter your ciphertext. Ciphertexts use characters only from the Latin Alphabet:"))?;
+    let ciphertxt: Ciphertext = process_input(|| {
+        println!(
+            "\nEnter your ciphertext. Ciphertexts use characters only from the Latin Alphabet:"
+        )
+    })?;
 
     // Attempt decryption or stop trying
     match command {
@@ -76,7 +80,9 @@ pub fn decrypt(command: DecryptMenu) -> Result<(), Box<dyn Error>> {
 /// Gets key from stdin and attempts to decrypt.
 pub fn chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>> {
     loop {
-        let key: Key = process_input(|| println!("\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive."))?;
+        let key: Key = process_input(|| {
+            println!("\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive.")
+        })?;
         match try_decrypt(ciphertxt, key) {
             Ok(_) => break,
             Err(_) => continue,
@@ -105,9 +111,10 @@ pub fn try_decrypt(ciphertxt: &Ciphertext, key: Key) -> Result<(), Box<dyn Error
         "\nYour computed plaintext is {}\n",
         ShiftCipher::decrypt(ciphertxt, &key)
     );
-      
+
     let command: ConsentMenu = process_input(|| {
-        println!("\nAre you happy with this decryption?");ConsentMenu::print_menu()
+        println!("\nAre you happy with this decryption?");
+        ConsentMenu::print_menu()
     })?;
 
     match command {

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -46,7 +46,9 @@ pub fn encrypt() -> Result<(), Box<dyn Error>> {
 
     println!("\nNow, do you have a key that was generated uniformly at random that you remember and \nwould like to use? If yes, please enter your key. Otherwise, please pick a fresh key \nuniformly at random from the ring of integers modulo 26 yourself. \n\nYou won't be as good at this as a computer, but if you understand the cryptosystem \nyou are using (something we cryptographers routinely assume about other people, while \npretending that we aren't assuming this), you will probably not pick a key of 0, \nwhich is equivalent to sending your messages \"in the clear\", i.e., unencrypted. Good \nluck! \n");
 
-    let key: Key = process_input(|| println!("\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive."))?;
+    let key: Key = process_input(|| {
+        println!("\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive.")
+    })?;
 
     println!("\nYour ciphertext is {}", ShiftCipher::encrypt(&msg, &key));
     println!("\nLook for patterns in your ciphertext. Could you definitively figure out the key and \noriginal plaintext message if you didn't already know it?");

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -46,7 +46,7 @@ pub fn encrypt() -> Result<(), Box<dyn Error>> {
 
     println!("\nNow, do you have a key that was generated uniformly at random that you remember and \nwould like to use? If yes, please enter your key. Otherwise, please pick a fresh key \nuniformly at random from the ring of integers modulo 26 yourself. \n\nYou won't be as good at this as a computer, but if you understand the cryptosystem \nyou are using (something we cryptographers routinely assume about other people, while \npretending that we aren't assuming this), you will probably not pick a key of 0, \nwhich is equivalent to sending your messages \"in the clear\", i.e., unencrypted. Good \nluck! \n");
 
-    let key: Key = process_input(|| println!("\nGo ahead and enter your key now:"))?;
+    let key: Key = process_input(|| println!("\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive."))?;
 
     println!("\nYour ciphertext is {}", ShiftCipher::encrypt(&msg, &key));
     println!("\nLook for patterns in your ciphertext. Could you definitively figure out the key and \noriginal plaintext message if you didn't already know it?");

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -21,11 +21,12 @@ pub fn make_key() -> Result<(), Box<dyn Error>> {
 
         println!("\nWe generated your key successfully!.");
         println!("\nWe shouldn't export your key (or say, save it in logs), but we can!");
-        println!("Here it is: {}", ShiftCipher::insecure_key_export(&key));
-        println!("\nAre you happy with your key?");
-        ConsentMenu::print_menu();
-
-        let command: ConsentMenu = process_input(ConsentMenu::print_menu)?;
+        println!("Here it is: {}\n", ShiftCipher::insecure_key_export(&key));
+                
+        let command: ConsentMenu = process_input(|| {
+            println!("\nAre you happy with your key?");
+            ConsentMenu::print_menu()
+    })?;
 
         match command {
             ConsentMenu::NoKE => continue,
@@ -40,17 +41,12 @@ pub fn make_key() -> Result<(), Box<dyn Error>> {
 /// Takes in a key and a message and encrypts, then prints
 /// the result.
 pub fn encrypt() -> Result<(), Box<dyn Error>> {
-    println!("\nPlease enter the message you want to encrypt:");
+    
+    let msg: Message = process_input(|| println!("\nPlease enter the message you want to encrypt:"))?;
 
-    let msg: Message = process_input(|| {
-        println!("\nWe only accept lowercase letters from the Latin Alphabet, in one of the most awkward \nAPI decisions ever.");
-    })?;
+    println!("\nNow, do you have a key that was generated uniformly at random that you remember and \nwould like to use? If yes, please enter your key. Otherwise, please pick a fresh key \nuniformly at random from the ring of integers modulo 26 yourself. \n\nYou won't be as good at this as a computer, but if you understand the cryptosystem \nyou are using (something we cryptographers routinely assume about other people, while \npretending that we aren't assuming this), you will probably not pick a key of 0, \nwhich is equivalent to sending your messages \"in the clear\", i.e., unencrypted. Good \nluck! \n");
 
-    println!("\nNow, do you have a key that was generated uniformly at random that you remember and \nwould like to use? If yes, please enter your key. Otherwise, please pick a fresh key \nuniformly at random from the ring of integers modulo 26 yourself. \n\nYou won't be as good at this as a computer, but if you understand the cryptosystem \nyou are using (something we cryptographers routinely assume about other people, while \npretending that we aren't assuming this), you will probably not pick a key of 0, \nwhich is equivalent to sending your messages \"in the clear\", i.e., unencrypted. Good \nluck! \n\nGo ahead and enter your key now:");
-
-    let key: Key = process_input(|| {
-        println!("{KEY_PROMPT}");
-    })?;
+    let key: Key = process_input(|| println!("\nGo ahead and enter your key now:"))?;
 
     println!("\nYour ciphertext is {}", ShiftCipher::encrypt(&msg, &key));
     println!("\nLook for patterns in your ciphertext. Could you definitively figure out the key and \noriginal plaintext message if you didn't already know it?");
@@ -61,11 +57,7 @@ pub fn encrypt() -> Result<(), Box<dyn Error>> {
 /// Takes in a ciphertext and attempts to decrypt and
 /// print result.
 pub fn decrypt(command: DecryptMenu) -> Result<(), Box<dyn Error>> {
-    println!("\nEnter your ciphertext. Ciphertexts use characters only from the Latin Alphabet:");
-
-    let ciphertxt: Ciphertext = process_input(|| {
-        println!("\nCiphertext must contain characters from the Latin Alphabet only.");
-    })?;
+    let ciphertxt: Ciphertext = process_input(|| println!("\nEnter your ciphertext. Ciphertexts use characters only from the Latin Alphabet:"))?;
 
     // Attempt decryption or stop trying
     match command {
@@ -84,10 +76,7 @@ pub fn decrypt(command: DecryptMenu) -> Result<(), Box<dyn Error>> {
 /// Gets key from stdin and attempts to decrypt.
 pub fn chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>> {
     loop {
-        println!("\nOK. Please enter a key now:");
-        let key: Key = process_input(|| {
-            println!("{KEY_PROMPT}");
-        })?;
+        let key: Key = process_input(|| println!("\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive."))?;
         match try_decrypt(ciphertxt, key) {
             Ok(_) => break,
             Err(_) => continue,
@@ -104,7 +93,7 @@ pub fn computer_chosen_key(ciphertxt: &Ciphertext) -> Result<(), Box<dyn Error>>
         let key = Key::new(&mut rng);
         match try_decrypt(ciphertxt, key) {
             Ok(_) => break,
-            Err(_) => continue, // TODO: How to handle different errors independently?
+            Err(_) => continue,
         }
     }
     Ok(())
@@ -116,15 +105,13 @@ pub fn try_decrypt(ciphertxt: &Ciphertext, key: Key) -> Result<(), Box<dyn Error
         "\nYour computed plaintext is {}\n",
         ShiftCipher::decrypt(ciphertxt, &key)
     );
-    println!("\nAre you happy with this decryption?");
-    ConsentMenu::print_menu();
-
-    let command: ConsentMenu = process_input(ConsentMenu::print_menu)?;
+      
+    let command: ConsentMenu = process_input(|| {
+        println!("\nAre you happy with this decryption?");ConsentMenu::print_menu()
+    })?;
 
     match command {
         ConsentMenu::NoKE => Err("try again".into()),
         ConsentMenu::YesKE => Ok(()),
     }
 }
-
-const KEY_PROMPT: &str = "\nA key is a number between 0 and 25 inclusive.";

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -83,7 +83,7 @@ mod io_helper {
 
             let result: T = match input.trim().parse::<T>() {
                 Ok(txt) => txt,
-                Err(e) => {
+                Err(_e) => {
                     //println!("Error. {}", e);
                     continue;
                 }

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -54,7 +54,7 @@ pub fn decryption_menu() -> Result<DecryptMenu, Box<dyn Error>> {
     println!(
     "If not, don't despair. Just guess! On average, you can expect success using this \nsimple brute force attack method after trying 13 keys chosen uniformly at random."
     );
-   
+
     let command: DecryptMenu = process_input(DecryptMenu::print_menu)?;
     Ok(command)
 }
@@ -74,7 +74,7 @@ mod io_helper {
         F: Fn(),
     {
         loop {
-             // Print the instructions
+            // Print the instructions
             instr();
 
             let mut input = String::new();

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -76,6 +76,7 @@ mod io_helper {
     pub fn process_input<T, F>(instr: F) -> Result<T, Box<dyn Error>>
     where
         T: FromStr,
+        <T as std::str::FromStr>::Err: std::fmt::Display,
         F: Fn(),
     {
         loop {
@@ -85,8 +86,9 @@ mod io_helper {
 
             let result: T = match input.trim().parse::<T>() {
                 Ok(txt) => txt,
-                Err(_) => {
+                Err(e) => {
                     instr();
+                    println!("Error: {}", e);
                     println!("\nPlease try again:");
                     continue;
                 }

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -9,7 +9,7 @@ use crate::io_helper::process_input;
 use crate::menu::{DecryptMenu, MainMenu, Menu};
 
 /// Presents main menu and runs user selection.
-/// 
+///
 /// Prints main menu of user options and matches on user input to do one of:
 /// - Generate a key;
 /// - Encrypt a message;
@@ -40,7 +40,7 @@ pub fn menu() -> Result<(), Box<dyn Error>> {
 }
 
 /// Presents decryption menu and runs user selection.
-/// 
+///
 /// Prints menu of user decryption options and matches on user input to do one
 /// of:
 /// - Decrypt using a known key;

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -84,7 +84,7 @@ mod io_helper {
             let result: T = match input.trim().parse::<T>() {
                 Ok(txt) => txt,
                 Err(e) => {
-                    println!("Error: {}", e);
+                    //println!("Error. {}", e);
                     continue;
                 }
             };

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -17,9 +17,6 @@ use crate::menu::{DecryptMenu, MainMenu, Menu};
 /// - Quit the CLI application.
 pub fn menu() -> Result<(), Box<dyn Error>> {
     loop {
-        // Print the main menu
-        MainMenu::print_menu();
-
         // Get menu selection from user
         let command: MainMenu = process_input(MainMenu::print_menu)?;
 
@@ -57,10 +54,7 @@ pub fn decryption_menu() -> Result<DecryptMenu, Box<dyn Error>> {
     println!(
     "If not, don't despair. Just guess! On average, you can expect success using this \nsimple brute force attack method after trying 13 keys chosen uniformly at random."
     );
-    println!("Pick one of the following options:");
-
-    DecryptMenu::print_menu();
-
+   
     let command: DecryptMenu = process_input(DecryptMenu::print_menu)?;
     Ok(command)
 }
@@ -80,6 +74,9 @@ mod io_helper {
         F: Fn(),
     {
         loop {
+             // Print the instructions
+            instr();
+
             let mut input = String::new();
 
             io::stdin().read_line(&mut input)?;
@@ -87,9 +84,7 @@ mod io_helper {
             let result: T = match input.trim().parse::<T>() {
                 Ok(txt) => txt,
                 Err(e) => {
-                    instr();
                     println!("Error: {}", e);
-                    println!("\nPlease try again:");
                     continue;
                 }
             };

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -9,3 +9,4 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("\nWelcome to the Latin Shift Cipher Demo!");
     menu().inspect_err(|e| eprintln!("Application error: {e}"))
 }
+

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -9,4 +9,3 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("\nWelcome to the Latin Shift Cipher Demo!");
     menu().inspect_err(|e| eprintln!("Application error: {e}"))
 }
-

--- a/demo/src/menu.rs
+++ b/demo/src/menu.rs
@@ -1,4 +1,5 @@
 //! Menus.
+use core::fmt;
 use std::str::FromStr;
 
 /// Represents menu functionality.
@@ -183,3 +184,9 @@ pub struct Command<'a> {
 
 /// The error returned upon failure to parse a [`Command`] from a string.
 pub struct CommandError;
+
+impl fmt::Display for CommandError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Invalid command")
+    }
+}


### PR DESCRIPTION
* refactor using thiserror crate
* improve error messaging
* create new errors module to put error-handling logic in one place
* reduces code duplication in demo by adding trait bounds to the parser helper `process_input` requiring the output type's `FromStr` Error  to implement `Display`