### PR TITLE
Code quality

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,10 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - nightly
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+    - run: rustup component add clippy
     - name: Run Clippy
       run: cargo clippy --all-targets --all-features
     - name: Build

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -308,7 +308,6 @@ impl FromIterator<RingElement> for Message {
 /// A ciphertext of arbitrary length.
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 struct Ciphertext(Vec<RingElement>);
-
 /// Parse a ciphertext from a string.
 ///
 /// # Errors

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -267,10 +267,6 @@ impl fmt::Display for RingElement {
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 struct Message(Vec<RingElement>);
 
-/// A ciphertext of arbitrary length.
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
-struct Ciphertext(Vec<RingElement>);
-
 impl Message {
     /// Create a new message from a string.
     fn new(str: &str) -> Result<Message, EncodingError> {
@@ -308,6 +304,10 @@ impl FromIterator<RingElement> for Message {
         Message(iter.into_iter().collect())
     }
 }
+
+/// A ciphertext of arbitrary length.
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
+struct Ciphertext(Vec<RingElement>);
 
 /// Parse a ciphertext from a string.
 ///

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -472,7 +472,7 @@ mod tests {
     fn ring_elmt_encoding_panic() {
         // Sometimes you google to find out how to prevent things like backtraces
         // appearing in your output for tests that should panic
-        let f = |_: &std::panic::PanicInfo| {};
+        let f = |_: &std::panic::PanicHookInfo| {};
         std::panic::set_hook(Box::new(f));
         let _fail = RingElement(26).to_char();
     }

--- a/classical_crypto/src/lib.rs
+++ b/classical_crypto/src/lib.rs
@@ -361,6 +361,7 @@ fn from_str(s: &str) -> Result<Vec<RingElement>, ErrorRepr> {
         .into_iter()
         .map(|i| i.unwrap_err())
         .map(|ErrorRepr::RingElementEncodingError(i)| i)
+        // Filters out errors caused by spaces in input string
         .filter(|i| i != " ")
         .collect();
 
@@ -498,12 +499,27 @@ mod tests {
             MSG0.with(|msg| msg.clone()).to_string(),
             "wewillmeetatmidnight"
         ); // Message maps to string correctly
+
+        // Allow spaces
+        assert_eq!(
+            Message::new("i love cats"),
+            Ok(Message(vec![
+                RingElement(8),
+                RingElement(11),
+                RingElement(14),
+                RingElement(21),
+                RingElement(4),
+                RingElement(2),
+                RingElement(0),
+                RingElement(19),
+                RingElement(18)
+            ]))
+        );
     }
 
     #[test]
     // Malformed message errors.
     fn msg_encoding_error() {
-        println!("{}", Message::new("what; on earh#A").unwrap_err());
         assert_eq!(
             Message::new("we~ will Meet at midnight;"),
             Err(EncodingError::InvalidMessage(

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -147,13 +147,8 @@ impl FromStr for Key {
     type Err = EncodingError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let key = match i8::from_str(s) {
-            Ok(num) => num,
-            Err(_) => return Err(EncodingError::InvalidKey(s.to_string())),
-        };
-
-        match key {
-            x if (0..=25).contains(&x) => Ok(Key::from(RingElement::from_i8(key))),
+       match i8::from_str(s) {
+            Ok(x) if (0..=25).contains(&x) => Ok(Key::from(RingElement::from_i8(x))),
             _ => Err(EncodingError::InvalidKey(s.to_string())),
         }
     }
@@ -417,6 +412,18 @@ mod tests {
         assert_ne!(
             ShiftCipher::decrypt(&ShiftCipher::encrypt(&msg1, &key1), &key2),
             msg1
+        )
+    }
+
+    #[test]
+    fn new_key(){
+        assert_eq!(
+            Key::from_str("0").unwrap(),
+            Key(RingElement(0))
+        );
+        assert_eq!(
+            Key::from_str("5").unwrap(),
+            Key(RingElement(5))
         )
     }
 

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -342,7 +342,7 @@ mod tests {
     fn unchecked_dec_panic() {
         // Sometimes you google to find out how to prevent things like backtraces
         // appearing in your output for tests that should panic
-        let f = |_: &std::panic::PanicInfo| {};
+        let f = |_: &std::panic::PanicHookInfo| {};
         std::panic::set_hook(Box::new(f));
         let ciph = Ciphertext(Ciphtxt(vec![RingElement(65)]));
 

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -15,6 +15,8 @@ use std::{fmt::Display, str::FromStr};
 // ring of integers mod 26. We do this because we want to force library users to use types specific
 // to the Latin Shift cipher when using the Latin Shift Cipher, even though other ciphers may also
 // (mathematically and under the hood in the implementation) operate on the same underlying types
+// It also lets us to keep more complicated logic about the internal types in one place that is easily reusable and modifiable, while
+// ensuring these simple wrappers stay the same
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Ciphertext(Ciphtxt);
 
@@ -44,6 +46,8 @@ impl FromIterator<RingElement> for Ciphertext {
 //    specific to the Latin Shift cipher when using the Latin Shift Cipher, even though other
 //    ciphers may also (mathematically and under the hood in the implementation) operate on the same
 //    underlying types
+//    It also lets us to keep more complicated logic about the internal types in one place that is easily reusable and modifiable, while
+// ensuring these simple wrappers stay the same
 // 2. The Rust Book (19.3) offers guidance on using the `Deref` trait in the newtype pattern to automatically implement all methods defined on the inner type for the wrapper type. We do not do this because doing so makes for surprises in the API. Also note that this trick does not give you trait implementations defined on the inner type for the wrapper. See also discussion [`here`](https://rust-unofficial.github.io/patterns/anti_patterns/deref.html)
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Message(Msg);

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -147,7 +147,7 @@ impl FromStr for Key {
     type Err = EncodingError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-       match i8::from_str(s) {
+        match i8::from_str(s) {
             Ok(x) if (0..=25).contains(&x) => Ok(Key::from(RingElement::from_i8(x))),
             _ => Err(EncodingError::InvalidKey(s.to_string())),
         }
@@ -416,15 +416,9 @@ mod tests {
     }
 
     #[test]
-    fn new_key(){
-        assert_eq!(
-            Key::from_str("0").unwrap(),
-            Key(RingElement(0))
-        );
-        assert_eq!(
-            Key::from_str("5").unwrap(),
-            Key(RingElement(5))
-        )
+    fn new_key() {
+        assert_eq!(Key::from_str("0").unwrap(), Key(RingElement(0)));
+        assert_eq!(Key::from_str("5").unwrap(), Key(RingElement(5)))
     }
 
     #[test]

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -273,16 +273,6 @@ impl ShiftCipher {
     }
 }
 
-// TODO: Not implemented yet
-/// A custom error type that is returned from [`ShiftCipher::encrypt`].
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
-pub struct EncryptionError;
-
-// TODO: not implemented yet
-/// A custom error type that is returned from [`ShiftCipher::decrypt`].
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
-pub struct DecryptionError;
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/classical_crypto/src/shift.rs
+++ b/classical_crypto/src/shift.rs
@@ -15,8 +15,8 @@ use std::{fmt::Display, str::FromStr};
 // ring of integers mod 26. We do this because we want to force library users to use types specific
 // to the Latin Shift cipher when using the Latin Shift Cipher, even though other ciphers may also
 // (mathematically and under the hood in the implementation) operate on the same underlying types
-// It also lets us to keep more complicated logic about the internal types in one place that is easily reusable and modifiable, while
-// ensuring these simple wrappers stay the same
+// It also lets us to keep more complicated logic about the internal types in one place that is
+// easily reusable and modifiable, while ensuring these simple wrappers stay the same
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Ciphertext(Ciphtxt);
 
@@ -45,8 +45,8 @@ impl FromIterator<RingElement> for Ciphertext {
 //    ring of integers mod 26. We do this because we want to force library users to use types
 //    specific to the Latin Shift cipher when using the Latin Shift Cipher, even though other
 //    ciphers may also (mathematically and under the hood in the implementation) operate on the same
-//    underlying types
-//    It also lets us to keep more complicated logic about the internal types in one place that is easily reusable and modifiable, while
+//    underlying types It also lets us to keep more complicated logic about the internal types in
+//    one place that is easily reusable and modifiable, while
 // ensuring these simple wrappers stay the same
 // 2. The Rust Book (19.3) offers guidance on using the `Deref` trait in the newtype pattern to automatically implement all methods defined on the inner type for the wrapper type. We do not do this because doing so makes for surprises in the API. Also note that this trick does not give you trait implementations defined on the inner type for the wrapper. See also discussion [`here`](https://rust-unofficial.github.io/patterns/anti_patterns/deref.html)
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -26,13 +26,10 @@ pub fn make_key(mut reader: impl BufRead, mut writer: impl Write) -> Result<()> 
         println!("Here it is: {}\n", ShiftCipher::insecure_key_export(&key));
 
         'inner: loop {
-            match process_input(
-                || -> Result<(), std::io::Error> {
-                    writeln!(writer, "\nAre you happy with your key?")?;
-                    ConsentMenu::print_menu(writer.by_ref())
-                },
-                &mut reader,
-            ) {
+            writeln!(writer, "\nAre you happy with your key?")?;
+            ConsentMenu::print_menu(writer.by_ref())?;
+
+            match process_input(&mut reader) {
                 Ok(ConsentMenu::NoKE) => continue 'outer,
                 Ok(ConsentMenu::YesKE) => {
                     writeln!(writer, "\nGreat! We don't have a file system implemented (much less a secure one), so please \nremember your key in perpetuity!")?;
@@ -49,10 +46,9 @@ pub fn make_key(mut reader: impl BufRead, mut writer: impl Write) -> Result<()> 
 /// the result.
 pub fn encrypt(mut reader: impl BufRead, mut writer: impl Write) -> Result<()> {
     let msg = loop {
-        let msg = process_input::<Message, EncodingError, _, _>(
-            || writeln!(writer, "\nPlease enter the message you want to encrypt:"),
-            &mut reader,
-        );
+        writeln!(writer, "\nPlease enter the message you want to encrypt:")?;
+
+        let msg = process_input::<Message, EncodingError, _>(&mut reader);
 
         if let Ok(msg) = msg {
             break msg;
@@ -64,15 +60,12 @@ pub fn encrypt(mut reader: impl BufRead, mut writer: impl Write) -> Result<()> {
     writeln!(writer, "\nNow, do you have a key that was generated uniformly at random that you remember and \nwould like to use? If yes, please enter your key. Otherwise, please pick a fresh key \nuniformly at random from the ring of integers modulo 26 yourself. \n\nYou won't be as good at this as a computer, but if you understand the cryptosystem \nyou are using (something we cryptographers routinely assume about other people, while \npretending that we aren't assuming this), you will probably not pick a key of 0, \nwhich is equivalent to sending your messages \"in the clear\", i.e., unencrypted. Good \nluck! \n")?;
 
     let key = loop {
-        let key = process_input::<Key, EncodingError, _, _>(
-            || {
-                writeln!(
-                    writer,
-                    "\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive."
-                )
-            },
-            &mut reader,
-        );
+        writeln!(
+            writer,
+            "\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive."
+        )?;
+
+        let key = process_input::<Key, EncodingError, _>(&mut reader);
 
         if let Ok(key) = key {
             break key;
@@ -100,15 +93,12 @@ pub fn decrypt(
     mut writer: impl Write,
 ) -> Result<()> {
     let ciphertxt = loop {
-        let ciphertxt = process_input::<Ciphertext, EncodingError, _, _>(
-            || {
-                writeln!(
-                writer,
-                "\nEnter your ciphertext. Ciphertexts use characters only from the Latin Alphabet:"
-            )
-            },
-            &mut reader,
-        );
+        writeln!(
+            writer,
+            "\nEnter your ciphertext. Ciphertexts use characters only from the Latin Alphabet:"
+        )?;
+
+        let ciphertxt = process_input::<Ciphertext, EncodingError, _>(&mut reader);
 
         if let Ok(ciphertxt) = ciphertxt {
             break ciphertxt;
@@ -124,7 +114,7 @@ pub fn decrypt(
             Ok(())
         }
         DecryptMenu::KnownKey => {
-            chosen_key(&ciphertxt, &mut reader, writer);
+            chosen_key(&ciphertxt, &mut reader, writer)?;
             Ok(())
         }
         DecryptMenu::Quit => Ok(()),
@@ -132,18 +122,19 @@ pub fn decrypt(
 }
 
 /// Gets key from stdin and attempts to decrypt.
-pub fn chosen_key(ciphertxt: &Ciphertext, mut reader: impl BufRead, mut writer: impl Write) {
+pub fn chosen_key(
+    ciphertxt: &Ciphertext,
+    mut reader: impl BufRead,
+    mut writer: impl Write,
+) -> Result<()> {
     loop {
+        writeln!(
+            writer,
+            "\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive."
+        )?;
+
         let key = loop {
-            let key = process_input::<Key, EncodingError, _, _>(
-                || {
-                    writeln!(
-                        writer,
-                        "\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive."
-                    )
-                },
-                &mut reader,
-            );
+            let key = process_input::<Key, EncodingError, _>(&mut reader);
 
             if let Ok(key) = key {
                 break key;
@@ -153,7 +144,7 @@ pub fn chosen_key(ciphertxt: &Ciphertext, mut reader: impl BufRead, mut writer: 
         };
 
         match try_decrypt(ciphertxt, key, &mut reader, writer.by_ref()) {
-            Ok(_) => break,
+            Ok(_) => break Ok(()),
             Err(_) => continue,
         }
     }
@@ -190,13 +181,10 @@ pub fn try_decrypt(
     );
 
     let command = loop {
-        let command = process_input::<ConsentMenu, ProcessInputError, _, _>(
-            || {
-                writeln!(writer, "\nAre you happy with this decryption?")?;
-                ConsentMenu::print_menu(writer.by_ref())
-            },
-            &mut reader,
-        );
+        writeln!(writer, "\nAre you happy with this decryption?")?;
+        ConsentMenu::print_menu(writer.by_ref())?;
+
+        let command = process_input::<ConsentMenu, ProcessInputError, _>(&mut reader);
 
         if let Ok(command) = command {
             break command;

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -1,12 +1,11 @@
 //! Cryptography-related I/O functionality.
 use crate::{
-    io_helper::{process_input, ProcessInputError},
+    io_helper::process_input,
     menu::{ConsentMenu, DecryptMenu, Menu},
 };
 use anyhow::{anyhow, Result};
 use classical_crypto::{
-    errors::EncodingError,
-    shift::{Ciphertext, Key, Message, ShiftCipher},
+    shift::{Ciphertext, Key, ShiftCipher},
     CipherTrait, KeyTrait,
 };
 use rand::thread_rng;
@@ -75,7 +74,7 @@ pub fn encrypt(mut reader: impl BufRead, mut writer: impl Write) -> Result<()> {
         match key {
             Ok(key) => break key,
             Err(e) => {
-                writeln! {writer, "Error: {}", e}?;
+                writeln!(writer, "Error: {}", e)?;
                 continue;
             }
         }

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -4,6 +4,7 @@ use crate::{
     menu::{ConsentMenu, DecryptMenu, Menu},
 };
 use anyhow::{anyhow, Result};
+use std::io::stdin;
 use classical_crypto::{
     shift::{Ciphertext, Key, Message, ShiftCipher},
     CipherTrait, KeyTrait,
@@ -26,7 +27,7 @@ pub fn make_key() -> Result<()> {
         let command: ConsentMenu = process_input(|| {
             println!("\nAre you happy with your key?");
             ConsentMenu::print_menu()
-        })?;
+        }, stdin().lock())?;
 
         match command {
             ConsentMenu::NoKE => continue,
@@ -42,13 +43,13 @@ pub fn make_key() -> Result<()> {
 /// the result.
 pub fn encrypt() -> Result<()> {
     let msg: Message =
-        process_input(|| println!("\nPlease enter the message you want to encrypt:"))?;
+        process_input(|| println!("\nPlease enter the message you want to encrypt:"), stdin().lock())?;
 
     println!("\nNow, do you have a key that was generated uniformly at random that you remember and \nwould like to use? If yes, please enter your key. Otherwise, please pick a fresh key \nuniformly at random from the ring of integers modulo 26 yourself. \n\nYou won't be as good at this as a computer, but if you understand the cryptosystem \nyou are using (something we cryptographers routinely assume about other people, while \npretending that we aren't assuming this), you will probably not pick a key of 0, \nwhich is equivalent to sending your messages \"in the clear\", i.e., unencrypted. Good \nluck! \n");
 
     let key: Key = process_input(|| {
         println!("\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive.")
-    })?;
+    }, stdin().lock())?;
 
     println!("\nYour ciphertext is {}", ShiftCipher::encrypt(&msg, &key));
     println!("\nLook for patterns in your ciphertext. Could you definitively figure out the key and \noriginal plaintext message if you didn't already know it?");
@@ -63,7 +64,7 @@ pub fn decrypt(command: DecryptMenu) -> Result<()> {
         println!(
             "\nEnter your ciphertext. Ciphertexts use characters only from the Latin Alphabet:"
         )
-    })?;
+    }, stdin().lock())?;
 
     // Attempt decryption or stop trying
     match command {
@@ -84,7 +85,7 @@ pub fn chosen_key(ciphertxt: &Ciphertext) -> Result<()> {
     loop {
         let key: Key = process_input(|| {
             println!("\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive.")
-        })?;
+        }, stdin().lock())?;
         match try_decrypt(ciphertxt, key) {
             Ok(_) => break,
             Err(_) => continue,
@@ -117,7 +118,7 @@ pub fn try_decrypt(ciphertxt: &Ciphertext, key: Key) -> Result<()> {
     let command: ConsentMenu = process_input(|| {
         println!("\nAre you happy with this decryption?");
         ConsentMenu::print_menu()
-    })?;
+    }, stdin().lock())?;
 
     match command {
         ConsentMenu::NoKE => Err(anyhow!("try again")),

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -9,52 +9,59 @@ use classical_crypto::{
     CipherTrait, KeyTrait,
 };
 use rand::thread_rng;
-use std::io::stdin;
+use std::io::{stdin, BufReader};
 
 /// Creates keys and prints the key to standard output.
 pub fn make_key() -> Result<()> {
     // Set up an rng.
     let mut rng = thread_rng();
 
-    loop {
+    'outer: loop {
         // Generate a key
         let key = Key::new(&mut rng);
 
         println!("\nWe generated your key successfully!.");
         println!("\nWe shouldn't export your key (or say, save it in logs), but we can!");
         println!("Here it is: {}\n", ShiftCipher::insecure_key_export(&key));
+        
+        let mut reader = BufReader::new(std::io::stdin());
 
-        let command: ConsentMenu = process_input(
+        'inner: loop {
+            println!("before asking");
+        match process_input(
             || {
                 println!("\nAre you happy with your key?");
-                ConsentMenu::print_menu()
+                ConsentMenu::print_menu();
             },
-            stdin().lock(),
-        )?;
-
-        match command {
-            ConsentMenu::NoKE => continue,
-            ConsentMenu::YesKE => {
+            &mut reader,
+        ) {
+            Ok(ConsentMenu::NoKE) => continue 'outer,
+            Ok(ConsentMenu::YesKE) => {
                 println!("\nGreat! We don't have a file system implemented (much less a secure one), so please \nremember your key in perpetuity!");
-                break Ok(());
+                break 'outer Ok(());
             }
+            Err(_) => continue 'inner
         };
     }
+}
 }
 
 /// Takes in a key and a message and encrypts, then prints
 /// the result.
 pub fn encrypt() -> Result<()> {
+    let mut reader = BufReader::new(std::io::stdin());
+
     let msg: Message = process_input(
         || println!("\nPlease enter the message you want to encrypt:"),
-        stdin().lock(),
+        &mut reader,
     )?;
 
     println!("\nNow, do you have a key that was generated uniformly at random that you remember and \nwould like to use? If yes, please enter your key. Otherwise, please pick a fresh key \nuniformly at random from the ring of integers modulo 26 yourself. \n\nYou won't be as good at this as a computer, but if you understand the cryptosystem \nyou are using (something we cryptographers routinely assume about other people, while \npretending that we aren't assuming this), you will probably not pick a key of 0, \nwhich is equivalent to sending your messages \"in the clear\", i.e., unencrypted. Good \nluck! \n");
 
+
     let key: Key = process_input(
         || println!("\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive."),
-        stdin().lock(),
+        &mut reader,
     )?;
 
     println!("\nYour ciphertext is {}", ShiftCipher::encrypt(&msg, &key));
@@ -66,13 +73,15 @@ pub fn encrypt() -> Result<()> {
 /// Takes in a ciphertext and attempts to decrypt and
 /// print result.
 pub fn decrypt(command: DecryptMenu) -> Result<()> {
+    let mut reader = BufReader::new(std::io::stdin());
+
     let ciphertxt: Ciphertext = process_input(
         || {
             println!(
                 "\nEnter your ciphertext. Ciphertexts use characters only from the Latin Alphabet:"
             )
         },
-        stdin().lock(),
+        &mut reader,
     )?;
 
     // Attempt decryption or stop trying
@@ -92,9 +101,11 @@ pub fn decrypt(command: DecryptMenu) -> Result<()> {
 /// Gets key from stdin and attempts to decrypt.
 pub fn chosen_key(ciphertxt: &Ciphertext) -> Result<()> {
     loop {
+        let mut reader = BufReader::new(std::io::stdin());
+
         let key: Key = process_input(
             || println!("\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive."),
-            stdin().lock(),
+            &mut reader,
         )?;
         match try_decrypt(ciphertxt, key) {
             Ok(_) => break,
@@ -125,12 +136,14 @@ pub fn try_decrypt(ciphertxt: &Ciphertext, key: Key) -> Result<()> {
         ShiftCipher::decrypt(ciphertxt, &key)
     );
 
+    let mut reader = BufReader::new(std::io::stdin());
+
     let command: ConsentMenu = process_input(
         || {
             println!("\nAre you happy with this decryption?");
             ConsentMenu::print_menu()
         },
-        stdin().lock(),
+        &mut reader,
     )?;
 
     match command {

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -9,7 +9,7 @@ use classical_crypto::{
     CipherTrait, KeyTrait,
 };
 use rand::thread_rng;
-use std::io::{stdin, BufReader};
+use std::io::BufReader;
 
 /// Creates keys and prints the key to standard output.
 pub fn make_key() -> Result<()> {

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -4,12 +4,12 @@ use crate::{
     menu::{ConsentMenu, DecryptMenu, Menu},
 };
 use anyhow::{anyhow, Result};
-use std::io::stdin;
 use classical_crypto::{
     shift::{Ciphertext, Key, Message, ShiftCipher},
     CipherTrait, KeyTrait,
 };
 use rand::thread_rng;
+use std::io::stdin;
 
 /// Creates keys and prints the key to standard output.
 pub fn make_key() -> Result<()> {
@@ -24,10 +24,13 @@ pub fn make_key() -> Result<()> {
         println!("\nWe shouldn't export your key (or say, save it in logs), but we can!");
         println!("Here it is: {}\n", ShiftCipher::insecure_key_export(&key));
 
-        let command: ConsentMenu = process_input(|| {
-            println!("\nAre you happy with your key?");
-            ConsentMenu::print_menu()
-        }, stdin().lock())?;
+        let command: ConsentMenu = process_input(
+            || {
+                println!("\nAre you happy with your key?");
+                ConsentMenu::print_menu()
+            },
+            stdin().lock(),
+        )?;
 
         match command {
             ConsentMenu::NoKE => continue,
@@ -42,14 +45,17 @@ pub fn make_key() -> Result<()> {
 /// Takes in a key and a message and encrypts, then prints
 /// the result.
 pub fn encrypt() -> Result<()> {
-    let msg: Message =
-        process_input(|| println!("\nPlease enter the message you want to encrypt:"), stdin().lock())?;
+    let msg: Message = process_input(
+        || println!("\nPlease enter the message you want to encrypt:"),
+        stdin().lock(),
+    )?;
 
     println!("\nNow, do you have a key that was generated uniformly at random that you remember and \nwould like to use? If yes, please enter your key. Otherwise, please pick a fresh key \nuniformly at random from the ring of integers modulo 26 yourself. \n\nYou won't be as good at this as a computer, but if you understand the cryptosystem \nyou are using (something we cryptographers routinely assume about other people, while \npretending that we aren't assuming this), you will probably not pick a key of 0, \nwhich is equivalent to sending your messages \"in the clear\", i.e., unencrypted. Good \nluck! \n");
 
-    let key: Key = process_input(|| {
-        println!("\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive.")
-    }, stdin().lock())?;
+    let key: Key = process_input(
+        || println!("\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive."),
+        stdin().lock(),
+    )?;
 
     println!("\nYour ciphertext is {}", ShiftCipher::encrypt(&msg, &key));
     println!("\nLook for patterns in your ciphertext. Could you definitively figure out the key and \noriginal plaintext message if you didn't already know it?");
@@ -60,11 +66,14 @@ pub fn encrypt() -> Result<()> {
 /// Takes in a ciphertext and attempts to decrypt and
 /// print result.
 pub fn decrypt(command: DecryptMenu) -> Result<()> {
-    let ciphertxt: Ciphertext = process_input(|| {
-        println!(
-            "\nEnter your ciphertext. Ciphertexts use characters only from the Latin Alphabet:"
-        )
-    }, stdin().lock())?;
+    let ciphertxt: Ciphertext = process_input(
+        || {
+            println!(
+                "\nEnter your ciphertext. Ciphertexts use characters only from the Latin Alphabet:"
+            )
+        },
+        stdin().lock(),
+    )?;
 
     // Attempt decryption or stop trying
     match command {
@@ -83,9 +92,10 @@ pub fn decrypt(command: DecryptMenu) -> Result<()> {
 /// Gets key from stdin and attempts to decrypt.
 pub fn chosen_key(ciphertxt: &Ciphertext) -> Result<()> {
     loop {
-        let key: Key = process_input(|| {
-            println!("\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive.")
-        }, stdin().lock())?;
+        let key: Key = process_input(
+            || println!("\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive."),
+            stdin().lock(),
+        )?;
         match try_decrypt(ciphertxt, key) {
             Ok(_) => break,
             Err(_) => continue,
@@ -115,10 +125,13 @@ pub fn try_decrypt(ciphertxt: &Ciphertext, key: Key) -> Result<()> {
         ShiftCipher::decrypt(ciphertxt, &key)
     );
 
-    let command: ConsentMenu = process_input(|| {
-        println!("\nAre you happy with this decryption?");
-        ConsentMenu::print_menu()
-    }, stdin().lock())?;
+    let command: ConsentMenu = process_input(
+        || {
+            println!("\nAre you happy with this decryption?");
+            ConsentMenu::print_menu()
+        },
+        stdin().lock(),
+    )?;
 
     match command {
         ConsentMenu::NoKE => Err(anyhow!("try again")),

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -23,27 +23,27 @@ pub fn make_key() -> Result<()> {
         println!("\nWe generated your key successfully!.");
         println!("\nWe shouldn't export your key (or say, save it in logs), but we can!");
         println!("Here it is: {}\n", ShiftCipher::insecure_key_export(&key));
-        
+
         let mut reader = BufReader::new(std::io::stdin());
 
         'inner: loop {
             println!("before asking");
-        match process_input(
-            || {
-                println!("\nAre you happy with your key?");
-                ConsentMenu::print_menu();
-            },
-            &mut reader,
-        ) {
-            Ok(ConsentMenu::NoKE) => continue 'outer,
-            Ok(ConsentMenu::YesKE) => {
-                println!("\nGreat! We don't have a file system implemented (much less a secure one), so please \nremember your key in perpetuity!");
-                break 'outer Ok(());
-            }
-            Err(_) => continue 'inner
-        };
+            match process_input(
+                || {
+                    println!("\nAre you happy with your key?");
+                    ConsentMenu::print_menu();
+                },
+                &mut reader,
+            ) {
+                Ok(ConsentMenu::NoKE) => continue 'outer,
+                Ok(ConsentMenu::YesKE) => {
+                    println!("\nGreat! We don't have a file system implemented (much less a secure one), so please \nremember your key in perpetuity!");
+                    break 'outer Ok(());
+                }
+                Err(_) => continue 'inner,
+            };
+        }
     }
-}
 }
 
 /// Takes in a key and a message and encrypts, then prints
@@ -57,7 +57,6 @@ pub fn encrypt() -> Result<()> {
     )?;
 
     println!("\nNow, do you have a key that was generated uniformly at random that you remember and \nwould like to use? If yes, please enter your key. Otherwise, please pick a fresh key \nuniformly at random from the ring of integers modulo 26 yourself. \n\nYou won't be as good at this as a computer, but if you understand the cryptosystem \nyou are using (something we cryptographers routinely assume about other people, while \npretending that we aren't assuming this), you will probably not pick a key of 0, \nwhich is equivalent to sending your messages \"in the clear\", i.e., unencrypted. Good \nluck! \n");
-
 
     let key: Key = process_input(
         || println!("\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive."),

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -25,7 +25,6 @@ pub fn make_key(mut reader: impl BufRead) -> Result<()> {
         println!("Here it is: {}\n", ShiftCipher::insecure_key_export(&key));
 
         'inner: loop {
-            println!("before asking");
             match process_input(
                 || {
                     println!("\nAre you happy with your key?");

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -36,7 +36,10 @@ pub fn make_key(mut reader: impl BufRead, mut writer: impl Write) -> Result<()> 
 
                     break 'outer Ok(());
                 }
-                Err(_) => continue 'inner,
+                Err(e) => {
+                    writeln!(writer, "Error: {}", e)?;
+                    continue 'inner;
+                }
             };
         }
     }
@@ -50,10 +53,12 @@ pub fn encrypt(mut reader: impl BufRead, mut writer: impl Write) -> Result<()> {
 
         let msg = process_input::<Message, EncodingError, _>(&mut reader);
 
-        if let Ok(msg) = msg {
-            break msg;
-        } else {
-            continue;
+        match msg {
+            Ok(msg) => break msg,
+            Err(e) => {
+                writeln!(writer, "Error: {}", e)?;
+                continue;
+            }
         }
     };
 
@@ -67,10 +72,12 @@ pub fn encrypt(mut reader: impl BufRead, mut writer: impl Write) -> Result<()> {
 
         let key = process_input::<Key, EncodingError, _>(&mut reader);
 
-        if let Ok(key) = key {
-            break key;
-        } else {
-            continue;
+        match key {
+            Ok(key) => break key,
+            Err(e) => {
+                writeln! {writer, "Error: {}", e}?;
+                continue;
+            }
         }
     };
 
@@ -100,10 +107,12 @@ pub fn decrypt(
 
         let ciphertxt = process_input::<Ciphertext, EncodingError, _>(&mut reader);
 
-        if let Ok(ciphertxt) = ciphertxt {
-            break ciphertxt;
-        } else {
-            continue;
+        match ciphertxt {
+            Ok(ciphertxt) => break ciphertxt,
+            Err(e) => {
+                writeln!(writer, "Error: {}", e)?;
+                continue;
+            }
         }
     };
 
@@ -136,10 +145,12 @@ pub fn chosen_key(
         let key = loop {
             let key = process_input::<Key, EncodingError, _>(&mut reader);
 
-            if let Ok(key) = key {
-                break key;
-            } else {
-                continue;
+            match key {
+                Ok(key) => break key,
+                Err(e) => {
+                    writeln!(writer, "Error: {}", e)?;
+                    continue;
+                }
             }
         };
 
@@ -186,10 +197,12 @@ pub fn try_decrypt(
 
         let command = process_input::<ConsentMenu, ProcessInputError, _>(&mut reader);
 
-        if let Ok(command) = command {
-            break command;
-        } else {
-            continue;
+        match command {
+            Ok(command) => break command,
+            Err(e) => {
+                writeln!(writer, "Error: {}", e)?;
+                continue;
+            }
         }
     };
 

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -34,7 +34,8 @@ pub fn make_key(mut reader: impl BufRead, mut writer: impl Write) -> Result<()> 
             ) {
                 Ok(ConsentMenu::NoKE) => continue 'outer,
                 Ok(ConsentMenu::YesKE) => {
-                    println!("\nGreat! We don't have a file system implemented (much less a secure one), so please \nremember your key in perpetuity!");
+                    writeln!(writer, "\nGreat! We don't have a file system implemented (much less a secure one), so please \nremember your key in perpetuity!")?;
+
                     break 'outer Ok(());
                 }
                 Err(_) => continue 'inner,
@@ -51,7 +52,7 @@ pub fn encrypt(mut reader: impl BufRead, mut writer: impl Write) -> Result<()> {
         &mut reader,
     )?;
 
-    println!("\nNow, do you have a key that was generated uniformly at random that you remember and \nwould like to use? If yes, please enter your key. Otherwise, please pick a fresh key \nuniformly at random from the ring of integers modulo 26 yourself. \n\nYou won't be as good at this as a computer, but if you understand the cryptosystem \nyou are using (something we cryptographers routinely assume about other people, while \npretending that we aren't assuming this), you will probably not pick a key of 0, \nwhich is equivalent to sending your messages \"in the clear\", i.e., unencrypted. Good \nluck! \n");
+    writeln!(writer, "\nNow, do you have a key that was generated uniformly at random that you remember and \nwould like to use? If yes, please enter your key. Otherwise, please pick a fresh key \nuniformly at random from the ring of integers modulo 26 yourself. \n\nYou won't be as good at this as a computer, but if you understand the cryptosystem \nyou are using (something we cryptographers routinely assume about other people, while \npretending that we aren't assuming this), you will probably not pick a key of 0, \nwhich is equivalent to sending your messages \"in the clear\", i.e., unencrypted. Good \nluck! \n")?;
 
     let key: Key = process_input(
         || {
@@ -68,6 +69,7 @@ pub fn encrypt(mut reader: impl BufRead, mut writer: impl Write) -> Result<()> {
         "\nYour ciphertext is {}",
         ShiftCipher::encrypt(&msg, &key)
     )?;
+
     writeln!(writer, "\nLook for patterns in your ciphertext. Could you definitively figure out the key and \noriginal plaintext message if you didn't already know it?")?;
 
     Ok(())

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -51,7 +51,7 @@ pub fn encrypt(mut reader: impl BufRead, mut writer: impl Write) -> Result<()> {
     let msg = loop {
         writeln!(writer, "\nPlease enter the message you want to encrypt:")?;
 
-        let msg = process_input::<Message, EncodingError, _>(&mut reader);
+        let msg = process_input(&mut reader);
 
         match msg {
             Ok(msg) => break msg,
@@ -70,7 +70,7 @@ pub fn encrypt(mut reader: impl BufRead, mut writer: impl Write) -> Result<()> {
             "\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive."
         )?;
 
-        let key = process_input::<Key, EncodingError, _>(&mut reader);
+        let key = process_input(&mut reader);
 
         match key {
             Ok(key) => break key,
@@ -105,7 +105,7 @@ pub fn decrypt(
             "\nEnter your ciphertext. Ciphertexts use characters only from the Latin Alphabet:"
         )?;
 
-        let ciphertxt = process_input::<Ciphertext, EncodingError, _>(&mut reader);
+        let ciphertxt = process_input(&mut reader);
 
         match ciphertxt {
             Ok(ciphertxt) => break ciphertxt,
@@ -143,7 +143,7 @@ pub fn chosen_key(
         )?;
 
         let key = loop {
-            let key = process_input::<Key, EncodingError, _>(&mut reader);
+            let key = process_input(&mut reader);
 
             match key {
                 Ok(key) => break key,
@@ -195,7 +195,7 @@ pub fn try_decrypt(
         writeln!(writer, "\nAre you happy with this decryption?")?;
         ConsentMenu::print_menu(writer.by_ref())?;
 
-        let command = process_input::<ConsentMenu, ProcessInputError, _>(&mut reader);
+        let command = process_input(&mut reader);
 
         match command {
             Ok(command) => break command,

--- a/demo/src/crypto_functionality.rs
+++ b/demo/src/crypto_functionality.rs
@@ -9,10 +9,10 @@ use classical_crypto::{
     CipherTrait, KeyTrait,
 };
 use rand::thread_rng;
-use std::io::BufRead;
+use std::io::{BufRead, Write};
 
 /// Creates keys and prints the key to standard output.
-pub fn make_key(mut reader: impl BufRead) -> Result<()> {
+pub fn make_key(mut reader: impl BufRead, mut writer: impl Write) -> Result<()> {
     // Set up an rng.
     let mut rng = thread_rng();
 
@@ -26,9 +26,9 @@ pub fn make_key(mut reader: impl BufRead) -> Result<()> {
 
         'inner: loop {
             match process_input(
-                || {
-                    println!("\nAre you happy with your key?");
-                    ConsentMenu::print_menu();
+                || -> Result<(), std::io::Error> {
+                    writeln!(writer, "\nAre you happy with your key?")?;
+                    ConsentMenu::print_menu(writer.by_ref())
                 },
                 &mut reader,
             ) {
@@ -45,31 +45,45 @@ pub fn make_key(mut reader: impl BufRead) -> Result<()> {
 
 /// Takes in a key and a message and encrypts, then prints
 /// the result.
-pub fn encrypt(mut reader: impl BufRead) -> Result<()> {
+pub fn encrypt(mut reader: impl BufRead, mut writer: impl Write) -> Result<()> {
     let msg: Message = process_input(
-        || println!("\nPlease enter the message you want to encrypt:"),
+        || writeln!(writer, "\nPlease enter the message you want to encrypt:"),
         &mut reader,
     )?;
 
     println!("\nNow, do you have a key that was generated uniformly at random that you remember and \nwould like to use? If yes, please enter your key. Otherwise, please pick a fresh key \nuniformly at random from the ring of integers modulo 26 yourself. \n\nYou won't be as good at this as a computer, but if you understand the cryptosystem \nyou are using (something we cryptographers routinely assume about other people, while \npretending that we aren't assuming this), you will probably not pick a key of 0, \nwhich is equivalent to sending your messages \"in the clear\", i.e., unencrypted. Good \nluck! \n");
 
     let key: Key = process_input(
-        || println!("\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive."),
+        || {
+            writeln!(
+                writer,
+                "\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive."
+            )
+        },
         &mut reader,
     )?;
 
-    println!("\nYour ciphertext is {}", ShiftCipher::encrypt(&msg, &key));
-    println!("\nLook for patterns in your ciphertext. Could you definitively figure out the key and \noriginal plaintext message if you didn't already know it?");
+    writeln!(
+        writer,
+        "\nYour ciphertext is {}",
+        ShiftCipher::encrypt(&msg, &key)
+    )?;
+    writeln!(writer, "\nLook for patterns in your ciphertext. Could you definitively figure out the key and \noriginal plaintext message if you didn't already know it?")?;
 
     Ok(())
 }
 
 /// Takes in a ciphertext and attempts to decrypt and
 /// print result.
-pub fn decrypt(command: DecryptMenu, mut reader: impl BufRead) -> Result<()> {
+pub fn decrypt(
+    command: DecryptMenu,
+    mut reader: impl BufRead,
+    mut writer: impl Write,
+) -> Result<()> {
     let ciphertxt: Ciphertext = process_input(
         || {
-            println!(
+            writeln!(
+                writer,
                 "\nEnter your ciphertext. Ciphertexts use characters only from the Latin Alphabet:"
             )
         },
@@ -79,11 +93,11 @@ pub fn decrypt(command: DecryptMenu, mut reader: impl BufRead) -> Result<()> {
     // Attempt decryption or stop trying
     match command {
         DecryptMenu::Bruteforce => {
-            computer_chosen_key(&ciphertxt, &mut reader)?;
+            computer_chosen_key(&ciphertxt, &mut reader, writer)?;
             Ok(())
         }
         DecryptMenu::KnownKey => {
-            chosen_key(&ciphertxt, &mut reader)?;
+            chosen_key(&ciphertxt, &mut reader, writer)?;
             Ok(())
         }
         DecryptMenu::Quit => Ok(()),
@@ -91,13 +105,22 @@ pub fn decrypt(command: DecryptMenu, mut reader: impl BufRead) -> Result<()> {
 }
 
 /// Gets key from stdin and attempts to decrypt.
-pub fn chosen_key(ciphertxt: &Ciphertext, mut reader: impl BufRead) -> Result<()> {
+pub fn chosen_key(
+    ciphertxt: &Ciphertext,
+    mut reader: impl BufRead,
+    mut writer: impl Write,
+) -> Result<()> {
     loop {
         let key: Key = process_input(
-            || println!("\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive."),
+            || {
+                writeln!(
+                    writer,
+                    "\nPlease enter a key now. Keys are numbers between 0 and 25 inclusive."
+                )
+            },
             &mut reader,
         )?;
-        match try_decrypt(ciphertxt, key, &mut reader) {
+        match try_decrypt(ciphertxt, key, &mut reader, writer.by_ref()) {
             Ok(_) => break,
             Err(_) => continue,
         }
@@ -106,12 +129,16 @@ pub fn chosen_key(ciphertxt: &Ciphertext, mut reader: impl BufRead) -> Result<()
 }
 
 /// Has computer choose key uniformly at random and attempts to decrypt.
-pub fn computer_chosen_key(ciphertxt: &Ciphertext, mut reader: impl BufRead) -> Result<()> {
+pub fn computer_chosen_key(
+    ciphertxt: &Ciphertext,
+    mut reader: impl BufRead,
+    mut writer: impl Write,
+) -> Result<()> {
     let mut rng = thread_rng();
 
     loop {
         let key = Key::new(&mut rng);
-        match try_decrypt(ciphertxt, key, &mut reader) {
+        match try_decrypt(ciphertxt, key, &mut reader, writer.by_ref()) {
             Ok(_) => break,
             Err(_) => continue,
         }
@@ -120,7 +147,12 @@ pub fn computer_chosen_key(ciphertxt: &Ciphertext, mut reader: impl BufRead) -> 
 }
 
 /// Decrypt with given key and ask whether to try again or not.
-pub fn try_decrypt(ciphertxt: &Ciphertext, key: Key, mut reader: impl BufRead) -> Result<()> {
+pub fn try_decrypt(
+    ciphertxt: &Ciphertext,
+    key: Key,
+    mut reader: impl BufRead,
+    mut writer: impl Write,
+) -> Result<()> {
     println!(
         "\nYour computed plaintext is {}\n",
         ShiftCipher::decrypt(ciphertxt, &key)
@@ -128,8 +160,8 @@ pub fn try_decrypt(ciphertxt: &Ciphertext, key: Key, mut reader: impl BufRead) -
 
     let command: ConsentMenu = process_input(
         || {
-            println!("\nAre you happy with this decryption?");
-            ConsentMenu::print_menu()
+            writeln!(writer, "\nAre you happy with this decryption?")?;
+            ConsentMenu::print_menu(writer.by_ref())
         },
         &mut reader,
     )?;

--- a/demo/src/io_helper.rs
+++ b/demo/src/io_helper.rs
@@ -1,14 +1,17 @@
 //! Utility function to help obtain a command from user via CLI.
-//!
 // Note how we test the CLI:
 // - First we divide the crate into a library and a binary
 // - Then we can test the library! This is a little tricky because we need to
 //   abstract over types that implement the [`std::io::BufRead`] trait in order
 //   to test read behavior.
-// 
-// This makes the code more complex and less understandable, so there is a testing tradeoff here. If we also want to test stdout behavior, we would have to remove any println! functionality in the code base and abstract over a generic that implements the [`std::io::Write`] method
-// TODO: Test stdout behavior
+//
+// This makes the code more complex and less understandable, so there is a
+// testing tradeoff here. If we also want to test stdout behavior, we would have
+// to remove any println! functionality in the code base and abstract over a
+// generic that implements the [`std::io::Write`] method TODO: Test stdout
+// behavior
 
+use anyhow::Result;
 use classical_crypto::errors::EncodingError;
 use std::{io, str::FromStr};
 use thiserror::Error;
@@ -29,18 +32,18 @@ pub enum ProcessInputError {
 /// Prints instructions and then processes command line input and converts to
 /// type `T` as specified by caller. If successful, returns conversion.
 /// Otherwise, returns an error.
-pub fn process_input<T, E, F, R>(instr: F, reader: &mut R) -> Result<T, ProcessInputError>
+pub fn process_input<T, E, F, R>(mut instr: F, reader: &mut R) -> Result<T, ProcessInputError>
 where
     T: FromStr<Err = E>,
     E: std::error::Error,
     // TODO: understand the `Fn` trait better
-    F: Fn(),
+    F: FnMut() -> Result<(), std::io::Error>,
     R: io::BufRead,
     ProcessInputError: std::convert::From<E>,
 {
     // Print the instructions
     // TODO Note: this is uhmm, obviously more general than that
-    instr();
+    instr()?;
 
     let mut input = String::new();
 
@@ -97,28 +100,28 @@ mod tests {
     #[test]
     fn ciphertext() {
         let mut mock_reader = MockIoReader::new("AFDSDFE");
-        let command: Ciphertext = process_input(|| {}, &mut mock_reader).unwrap();
+        let command: Ciphertext = process_input(|| Ok(()), &mut mock_reader).unwrap();
         assert_eq!(command, Ciphertext::from_str("AFDSDFE").unwrap())
     }
     //
     #[test]
     fn message() {
         let mut mock_reader = MockIoReader::new("thecatishungry");
-        let command: Message = process_input(|| {}, &mut mock_reader).unwrap();
+        let command: Message = process_input(|| Ok(()), &mut mock_reader).unwrap();
         assert_eq!(command, Message::new("thecatishungry").unwrap())
     }
     //
     #[test]
     fn key() {
         let mut mock_reader = MockIoReader::new("3");
-        let command: Key = process_input(|| {}, &mut mock_reader).unwrap();
+        let command: Key = process_input(|| Ok(()), &mut mock_reader).unwrap();
         assert_eq!(command, Key::from_str("3").unwrap())
     }
     //
     #[test]
     fn message_error() {
         let mut mock_reader = MockIoReader::new("N");
-        let error: Result<Message, ProcessInputError> = process_input(|| {}, &mut mock_reader);
+        let error: Result<Message, ProcessInputError> = process_input(|| Ok(()), &mut mock_reader);
 
         assert!(error.is_err());
 
@@ -132,7 +135,8 @@ mod tests {
     #[test]
     fn ciphertext_error() {
         let mut mock_reader = MockIoReader::new("ASD;");
-        let error: Result<Ciphertext, ProcessInputError> = process_input(|| {}, &mut mock_reader);
+        let error: Result<Ciphertext, ProcessInputError> =
+            process_input(|| Ok(()), &mut mock_reader);
 
         assert!(error.is_err());
 
@@ -146,7 +150,7 @@ mod tests {
     #[test]
     fn key_error() {
         let mut mock_reader = MockIoReader::new("65");
-        let error: Result<Key, ProcessInputError> = process_input(|| {}, &mut mock_reader);
+        let error: Result<Key, ProcessInputError> = process_input(|| Ok(()), &mut mock_reader);
 
         assert!(error.is_err());
         let error = error.as_ref().unwrap_err();
@@ -163,21 +167,22 @@ mod tests {
     #[test]
     fn assent() {
         let mut mock_reader = MockIoReader::new("y");
-        let command: ConsentMenu = process_input(|| {}, &mut mock_reader).unwrap();
+        let command: ConsentMenu = process_input(|| Ok(()), &mut mock_reader).unwrap();
         assert_eq!(command, ConsentMenu::YesKE)
     }
     //
     #[test]
     fn dissent() {
         let mut mock_reader = MockIoReader::new("n");
-        let command: ConsentMenu = process_input(|| {}, &mut mock_reader).unwrap();
+        let command: ConsentMenu = process_input(|| Ok(()), &mut mock_reader).unwrap();
         assert_eq!(command, ConsentMenu::NoKE)
     }
     //
     #[test]
     fn consent_error() {
         let mut mock_reader = MockIoReader::new("N");
-        let error: Result<ConsentMenu, ProcessInputError> = process_input(|| {}, &mut mock_reader);
+        let error: Result<ConsentMenu, ProcessInputError> =
+            process_input(|| Ok(()), &mut mock_reader);
 
         assert!(error.is_err());
 
@@ -191,28 +196,29 @@ mod tests {
     #[test]
     fn known_key() {
         let mut mock_reader = MockIoReader::new("1");
-        let command: DecryptMenu = process_input(|| {}, &mut mock_reader).unwrap();
+        let command: DecryptMenu = process_input(|| Ok(()), &mut mock_reader).unwrap();
         assert_eq!(command, DecryptMenu::KnownKey)
     }
     //
     #[test]
     fn brute_force() {
         let mut mock_reader = MockIoReader::new("2");
-        let command: DecryptMenu = process_input(|| {}, &mut mock_reader).unwrap();
+        let command: DecryptMenu = process_input(|| Ok(()), &mut mock_reader).unwrap();
         assert_eq!(command, DecryptMenu::Bruteforce)
     }
     //
     #[test]
     fn quit_decrypt_menu() {
         let mut mock_reader = MockIoReader::new("3");
-        let command: DecryptMenu = process_input(|| {}, &mut mock_reader).unwrap();
+        let command: DecryptMenu = process_input(|| Ok(()), &mut mock_reader).unwrap();
         assert_eq!(command, DecryptMenu::Quit)
     }
     //
     #[test]
     fn decrypt_menu_error() {
         let mut mock_reader = MockIoReader::new("N");
-        let error: Result<ConsentMenu, ProcessInputError> = process_input(|| {}, &mut mock_reader);
+        let error: Result<ConsentMenu, ProcessInputError> =
+            process_input(|| Ok(()), &mut mock_reader);
 
         assert!(error.is_err());
 
@@ -227,35 +233,35 @@ mod tests {
     #[test]
     fn main_gen_key() {
         let mut mock_reader = MockIoReader::new("1");
-        let command: MainMenu = process_input(|| {}, &mut mock_reader).unwrap();
+        let command: MainMenu = process_input(|| Ok(()), &mut mock_reader).unwrap();
         assert_eq!(command, MainMenu::GenKE)
     }
     //
     #[test]
     fn main_encrypt() {
         let mut mock_reader = MockIoReader::new("2");
-        let command: MainMenu = process_input(|| {}, &mut mock_reader).unwrap();
+        let command: MainMenu = process_input(|| Ok(()), &mut mock_reader).unwrap();
         assert_eq!(command, MainMenu::EncryptKE)
     }
     //
     #[test]
     fn main_decrypt() {
         let mut mock_reader = MockIoReader::new("3");
-        let command: MainMenu = process_input(|| {}, &mut mock_reader).unwrap();
+        let command: MainMenu = process_input(|| Ok(()), &mut mock_reader).unwrap();
         assert_eq!(command, MainMenu::DecryptKE)
     }
     //
     #[test]
     fn main_quit() {
         let mut mock_reader = MockIoReader::new("4");
-        let command: MainMenu = process_input(|| {}, &mut mock_reader).unwrap();
+        let command: MainMenu = process_input(|| Ok(()), &mut mock_reader).unwrap();
         assert_eq!(command, MainMenu::QuitKE)
     }
     //
     #[test]
     fn main_error() {
         let mut mock_reader = MockIoReader::new("N");
-        let error: Result<MainMenu, ProcessInputError> = process_input(|| {}, &mut mock_reader);
+        let error: Result<MainMenu, ProcessInputError> = process_input(|| Ok(()), &mut mock_reader);
 
         assert!(error.is_err());
 

--- a/demo/src/io_helper.rs
+++ b/demo/src/io_helper.rs
@@ -1,62 +1,69 @@
 //! Utility function to help obtain a command from user via CLI.
+//!
+//! Note how we test the CLI:
+//! - First we divide the crate into a library and a binary
+//! - Then we can test the library! This is a little tricky because we need to
+//!   abstract over types that implement the [`std::io::BufRead`] trait in order
+//!   to test read behavior.
 
-use anyhow::Result;
-use std::{io, os::unix::process, str::FromStr, sync::Condvar};
+use crate::menu::CommandError;
+use anyhow::{anyhow, Result};
+use std::{io, str::FromStr};
 
-use crate::menu::ConsentMenu;
 // TODO: this loop and match statment plus a return line is probably not
 // idiomatic
 //
-/// Processes command line input and converts to type `T` as specified
-/// by caller. If successful, returns conversion. If not, prints clarifying
-/// instructions so that the person can try again.
-pub fn process_input<T, F, R>(instr: F, mut reader: R) -> Result<T>
+/// Prints instructions and then processes command line input and converts to type `T` as specified
+/// by caller. If successful, returns conversion. Otherwise, returns an error.
+pub fn process_input<T, E, F, R>(instr: F, mut reader: R) -> Result<T>
 where
-    T: FromStr,
+    T: FromStr<Err = E>,
+    // TODO: Understand this
+    E: std::error::Error + std::marker::Send + std::marker::Sync + 'static,
     F: Fn(),
-    R: io::BufRead
+    R: io::BufRead,
 {
-    loop {
-        // Print the instructions
-        instr();
+    // Print the instructions
+    instr();
 
-        let mut input = String::new();
+    let mut input = String::new();
 
-        reader.read_line(&mut input)?;
+    reader.read_line(&mut input)?;
 
-        let result: T = match input.trim().parse::<T>() {
-            Ok(txt) => txt,
-            Err(_) => {
-                continue;
-            }
-        };
-
-        return Ok(result);
+    match input.trim().parse::<T>() {
+        Ok(t) => Ok(t),
+        Err(e) => Err(e.into()),
     }
 }
 
-mod test {
+mod tests {
+    // TODO: Why is this giving a warning?
     use super::*;
+    use crate::menu::ConsentMenu;
 
-#[test]
-fn assent(){
-    let input: &[u8] = b"y";
-    let command: ConsentMenu = process_input(||{}, input).unwrap();
-    assert_eq!(command, ConsentMenu::YesKE)}
-}
+    #[test]
+    fn assent() {
+        let input: &[u8] = b"y";
+        let command: ConsentMenu = process_input(|| {}, input).unwrap();
+        assert_eq!(command, ConsentMenu::YesKE)
+    }
 
-#[test]
-fn dissent(){
-    let input: &[u8] = b"n";
-    let command: ConsentMenu = process_input(||{}, input).unwrap();
-    assert_eq!(command, ConsentMenu::NoKE)
-}
+    #[test]
+    fn dissent() {
+        let input: &[u8] = b"n";
+        let command: ConsentMenu = process_input(|| {}, input).unwrap();
+        assert_eq!(command, ConsentMenu::NoKE)
+    }
 
-#[test]
-#[should_panic]
-fn consent_error(){
-    let input: &[u8] = b"N";
-    let error: anyhow::Error = process_input::<ConsentMenu, _, &[u8]>(||{}, input).unwrap_err();
-   
-    //assert_eq!(error.downcast_ref::, ConsentMenu::NoKE)
+    #[test]
+    fn consent_error() {
+        let input: &[u8] = b"N";
+        let error: anyhow::Error =
+            process_input::<ConsentMenu, CommandError, _, &[u8]>(|| {}, input).unwrap_err();
+
+        assert_eq!(
+            *error.downcast_ref::<CommandError>().unwrap(),
+            CommandError("N".to_string())
+        )
+    }
 }

--- a/demo/src/io_helper.rs
+++ b/demo/src/io_helper.rs
@@ -33,6 +33,9 @@ pub enum ProcessInputError {
 /// Prints instructions and then processes command line input and converts to
 /// type `T` as specified by caller. If successful, returns conversion.
 /// Otherwise, returns an error.
+// TODO Notes: 
+// - So generic that it's difficult to make sense of
+// - Might be a good use case for a macro
 pub fn process_input<T, E, F, R>(mut instr: F, reader: &mut R) -> Result<T, ProcessInputError>
 where
     T: FromStr<Err = E>,

--- a/demo/src/io_helper.rs
+++ b/demo/src/io_helper.rs
@@ -5,12 +5,11 @@
 //! - Then we can test the library! This is a little tricky because we need to
 //!   abstract over types that implement the [`std::io::BufRead`] trait in order
 //!   to test read behavior.
+// TODO: Test stdout behavior
 
 use classical_crypto::errors::EncodingError;
 use std::{io, str::FromStr};
 use thiserror::Error;
-
-// use anyhow::{anyhow, Result};
 
 #[derive(Error, Debug)]
 pub enum ProcessInputError {

--- a/demo/src/io_helper.rs
+++ b/demo/src/io_helper.rs
@@ -1,17 +1,20 @@
 //! Utility function to help obtain a command from user via CLI.
 
 use anyhow::Result;
-use std::{io, str::FromStr};
+use std::{io, os::unix::process, str::FromStr, sync::Condvar};
+
+use crate::menu::ConsentMenu;
 // TODO: this loop and match statment plus a return line is probably not
 // idiomatic
 //
 /// Processes command line input and converts to type `T` as specified
 /// by caller. If successful, returns conversion. If not, prints clarifying
 /// instructions so that the person can try again.
-pub fn process_input<T, F>(instr: F) -> Result<T>
+pub fn process_input<T, F, R>(instr: F, mut reader: R) -> Result<T>
 where
     T: FromStr,
     F: Fn(),
+    R: io::BufRead
 {
     loop {
         // Print the instructions
@@ -19,16 +22,41 @@ where
 
         let mut input = String::new();
 
-        io::stdin().read_line(&mut input)?;
+        reader.read_line(&mut input)?;
 
         let result: T = match input.trim().parse::<T>() {
             Ok(txt) => txt,
-            Err(_e) => {
-                //println!("Error. {}", e);
+            Err(_) => {
                 continue;
             }
         };
 
         return Ok(result);
     }
+}
+
+mod test {
+    use super::*;
+
+#[test]
+fn assent(){
+    let input: &[u8] = b"y";
+    let command: ConsentMenu = process_input(||{}, input).unwrap();
+    assert_eq!(command, ConsentMenu::YesKE)}
+}
+
+#[test]
+fn dissent(){
+    let input: &[u8] = b"n";
+    let command: ConsentMenu = process_input(||{}, input).unwrap();
+    assert_eq!(command, ConsentMenu::NoKE)
+}
+
+#[test]
+#[should_panic]
+fn consent_error(){
+    let input: &[u8] = b"N";
+    let error: anyhow::Error = process_input::<ConsentMenu, _, &[u8]>(||{}, input).unwrap_err();
+   
+    //assert_eq!(error.downcast_ref::, ConsentMenu::NoKE)
 }

--- a/demo/src/io_helper.rs
+++ b/demo/src/io_helper.rs
@@ -8,6 +8,9 @@
 //
 // This makes the code more complex and less understandable, so there is a
 // tradeoff here between readability and testability.
+//
+// Notes: we don't exhaustively test writes here, we tested printing the main
+// menu with user selecting to generate a key in
 
 use anyhow::Result;
 use classical_crypto::errors::EncodingError;
@@ -263,7 +266,6 @@ mod tests {
     fn main_gen_key() {
         let mut mock_reader = MockIoReader::new("1");
         let mut mock_writer = MockIoWriter::new();
-        dbg!(&mock_writer);
 
         let command: MainMenu =
             process_input(|| MainMenu::print_menu(&mut mock_writer), &mut mock_reader).unwrap();

--- a/demo/src/io_helper.rs
+++ b/demo/src/io_helper.rs
@@ -1,10 +1,12 @@
 //! Utility function to help obtain a command from user via CLI.
 //!
-//! Note how we test the CLI:
-//! - First we divide the crate into a library and a binary
-//! - Then we can test the library! This is a little tricky because we need to
-//!   abstract over types that implement the [`std::io::BufRead`] trait in order
-//!   to test read behavior.
+// Note how we test the CLI:
+// - First we divide the crate into a library and a binary
+// - Then we can test the library! This is a little tricky because we need to
+//   abstract over types that implement the [`std::io::BufRead`] trait in order
+//   to test read behavior.
+// 
+// This makes the code more complex and less understandable, so there is a testing tradeoff here. If we also want to test stdout behavior, we would have to remove any println! functionality in the code base and abstract over a generic that implements the [`std::io::Write`] method
 // TODO: Test stdout behavior
 
 use classical_crypto::errors::EncodingError;
@@ -32,7 +34,7 @@ where
     T: FromStr<Err = E>,
     E: std::error::Error,
     // TODO: understand the `Fn` trait better
-    F: FnOnce(),
+    F: Fn(),
     R: io::BufRead,
     ProcessInputError: std::convert::From<E>,
 {

--- a/demo/src/io_helper.rs
+++ b/demo/src/io_helper.rs
@@ -13,15 +13,16 @@ use std::{io, str::FromStr};
 // TODO: this loop and match statment plus a return line is probably not
 // idiomatic
 //
-/// Prints instructions and then processes command line input and converts to type `T` as specified
-/// by caller. If successful, returns conversion. Otherwise, returns an error.
-pub fn process_input<T, E, F, R>(instr: F, mut reader: R) -> Result<T>
+/// Prints instructions and then processes command line input and converts to
+/// type `T` as specified by caller. If successful, returns conversion.
+/// Otherwise, returns an error.
+pub fn process_input<T, E, F, R>(instr: F, reader: &mut R) -> Result<T>
 where
     T: FromStr<Err = E>,
     // TODO: Understand this
     E: std::error::Error + std::marker::Send + std::marker::Sync + 'static,
     F: Fn(),
-    R: io::BufRead,
+    R: io::BufRead, // TODO: or BufRead?
 {
     // Print the instructions
     instr();
@@ -36,34 +37,64 @@ where
     }
 }
 
+#[cfg(test)]
 mod tests {
     // TODO: Why is this giving a warning?
     use super::*;
+    use std::io::{Read, BufRead};
     use crate::menu::ConsentMenu;
+
+    struct MockIoReader {
+        mock_input: String,
+    }
+
+    impl MockIoReader {
+        fn new(mock_input: &str) -> Self {
+            Self { mock_input: mock_input.to_string() }
+        }
+    }
+
+    impl Read for MockIoReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            buf.clone_from_slice(self.mock_input.as_bytes());
+            Ok(self.mock_input.len())
+        }
+    }
+
+    impl BufRead for MockIoReader {
+        fn fill_buf(&mut self) -> io::Result<&[u8]> {
+            Ok(self.mock_input.as_bytes())
+        }
+
+        fn consume(&mut self, amt: usize) {
+            let (_, rest) = self.mock_input.split_at(amt);
+            self.mock_input = rest.to_string();
+        }
+    }
 
     #[test]
     fn assent() {
-        let input: &[u8] = b"y";
-        let command: ConsentMenu = process_input(|| {}, input).unwrap();
+        let mut mock_reader = MockIoReader::new("y");
+        let command: ConsentMenu = process_input(|| {println!{"test"}}, &mut mock_reader).unwrap();
         assert_eq!(command, ConsentMenu::YesKE)
     }
 
-    #[test]
-    fn dissent() {
-        let input: &[u8] = b"n";
-        let command: ConsentMenu = process_input(|| {}, input).unwrap();
-        assert_eq!(command, ConsentMenu::NoKE)
-    }
+    // #[test]
+    // fn dissent() {
+    //     let input: &[u8] = b"n";
+    //     let command: ConsentMenu = process_input(|| {}, input).unwrap();
+    //     assert_eq!(command, ConsentMenu::NoKE)
+    // }
 
-    #[test]
-    fn consent_error() {
-        let input: &[u8] = b"N";
-        let error: anyhow::Error =
-            process_input::<ConsentMenu, CommandError, _, &[u8]>(|| {}, input).unwrap_err();
+    // #[test]
+    // fn consent_error() {
+    //     let input: &[u8] = b"N";
+    //     let error: anyhow::Error =
+    //         process_input::<ConsentMenu, CommandError, _, &[u8]>(|| {}, input).unwrap_err();
 
-        assert_eq!(
-            *error.downcast_ref::<CommandError>().unwrap(),
-            CommandError("N".to_string())
-        )
-    }
+    //     assert_eq!(
+    //         *error.downcast_ref::<CommandError>().unwrap(),
+    //         CommandError("N".to_string())
+    //     )
+    // }
 }

--- a/demo/src/io_helper.rs
+++ b/demo/src/io_helper.rs
@@ -76,6 +76,7 @@ mod tests {
     // Create a mock object to test writing to `stdout`
     #[derive(Debug)]
     struct MockIoWriter {
+        buffer: Vec<u8>,
         mock_output: String,
     }
 
@@ -90,6 +91,7 @@ mod tests {
     impl MockIoWriter {
         fn new() -> Self {
             Self {
+                buffer: Vec::new(),
                 mock_output: "".to_string(),
             }
         }
@@ -115,12 +117,13 @@ mod tests {
 
     impl Write for MockIoWriter {
         fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            self.mock_output.push_str(str::from_utf8(buf).unwrap());
-            Ok(buf.len())
+            self.buffer = buf.to_vec();
+            Ok(self.buffer.len())
         }
 
         // Not using this
         fn flush(&mut self) -> io::Result<()> {
+            self.mock_output = String::from_utf8_lossy(&self.buffer).to_string();
             Ok(())
         }
     }

--- a/demo/src/io_helper.rs
+++ b/demo/src/io_helper.rs
@@ -32,7 +32,7 @@ where
     T: FromStr<Err = E>,
     E: std::error::Error,
     // TODO: understand the `Fn` trait better
-    F: Fn(),
+    F: FnOnce(),
     R: io::BufRead,
     ProcessInputError: std::convert::From<E>,
 {
@@ -48,6 +48,10 @@ where
 }
 
 // TODO: Is this a good place for a macro? These tests are _very_ repetitive.
+// Test notes: these tests test `process_input`, which converts a user input to
+// a prespecified type, which are of two kinds in our demo
+// - types inherited from the classical_crypto library,
+// - commands
 #[cfg(test)]
 mod tests {
     use classical_crypto::shift::{Ciphertext, Key, Message};

--- a/demo/src/io_helper.rs
+++ b/demo/src/io_helper.rs
@@ -30,12 +30,11 @@ pub enum ProcessInputError {
     CommandParseError(String),
 }
 
-/// Prints instructions and then processes command line input and converts to
+/// Processes user input and converts to
 /// type `T` as specified by caller. If successful, returns conversion.
-/// Otherwise, returns an error.
-// TODO Notes:
-// - So generic that it's difficult to make sense of
-// - Might be a good use case for a macro
+/// Otherwise, returns a custom error that contains information about the
+/// underlying error cause.
+// Notes: This is generic over the reader in order to decouple the program from stdin and allow for easier testing.
 pub fn process_input<T, E, R>(reader: &mut R) -> Result<T, ProcessInputError>
 where
     T: FromStr<Err = E>,

--- a/demo/src/io_helper.rs
+++ b/demo/src/io_helper.rs
@@ -30,13 +30,14 @@ pub enum ProcessInputError {
 pub fn process_input<T, E, F, R>(instr: F, reader: &mut R) -> Result<T, ProcessInputError>
 where
     T: FromStr<Err = E>,
-    // TODO: Understand this
     E: std::error::Error,
+    // TODO: understand the `Fn` trait better
     F: Fn(),
     R: io::BufRead,
     ProcessInputError: std::convert::From<E>,
 {
     // Print the instructions
+    // TODO Note: this is uhmm, obviously more general than that
     instr();
 
     let mut input = String::new();

--- a/demo/src/io_helper.rs
+++ b/demo/src/io_helper.rs
@@ -30,6 +30,7 @@ pub enum ProcessInputError {
     CommandParseError(String),
 }
 
+#[macro_export]
 macro_rules! process_input {
     ($reader:expr) => {{
         let mut input = String::new();

--- a/demo/src/io_helper.rs
+++ b/demo/src/io_helper.rs
@@ -116,7 +116,8 @@ mod tests {
         assert!(error.is_err());
 
         assert!(match error.unwrap_err() {
-            ProcessInputError::CryptoParseError(e) => e.to_string() == "Invalid Message. Failed to encode the following characters as ring elements: N",
+            ProcessInputError::CryptoParseError(e) => e.to_string()
+                == "Invalid Message. Failed to encode the following characters as ring elements: N",
             _ => false,
         });
     }
@@ -127,7 +128,7 @@ mod tests {
         let error: Result<Ciphertext, ProcessInputError> = process_input(|| {}, &mut mock_reader);
 
         assert!(error.is_err());
-      
+
         assert!(match error.unwrap_err() {
             ProcessInputError::CryptoParseError(e) => e.to_string() == "Invalid Ciphertext. Failed to encode the following characters as ring elements: ;",
             _ => false,
@@ -142,10 +143,12 @@ mod tests {
 
         assert!(error.is_err());
         let error = error.as_ref().unwrap_err();
-        assert_eq!(error.to_string(), "Parse error: Input \"65\" does not represent a valid key");
-        
-        assert!(matches!(error, ProcessInputError::CryptoParseError(_))
-    );
+        assert_eq!(
+            error.to_string(),
+            "Parse error: Input \"65\" does not represent a valid key"
+        );
+
+        assert!(matches!(error, ProcessInputError::CryptoParseError(_)));
     }
 
     // ConsentMenu tests

--- a/demo/src/io_helper.rs
+++ b/demo/src/io_helper.rs
@@ -162,7 +162,7 @@ mod tests {
         Ok(())
     }
 
-    // EncodingError tests
+    // Processing Ciphertexts, Messages, Keys
     #[test]
     fn ciphertext() -> anyhow::Result<()> {
         let mut mock_reader = MockIoReader::new("AFDSDFE");
@@ -183,15 +183,15 @@ mod tests {
     #[test]
     fn message() {
         let mut mock_reader = MockIoReader::new("thecatishungry");
-        let command: Message = process_input(&mut mock_reader).unwrap();
-        assert_eq!(command, Message::new("thecatishungry").unwrap())
+        let msg: Message = process_input(&mut mock_reader).unwrap();
+        assert_eq!(msg, Message::new("thecatishungry").unwrap())
     }
     //
     #[test]
     fn key() {
         let mut mock_reader = MockIoReader::new("3");
-        let command: Key = process_input(&mut mock_reader).unwrap();
-        assert_eq!(command, Key::from_str("3").unwrap())
+        let key: Key = process_input(&mut mock_reader).unwrap();
+        assert_eq!(key, Key::from_str("3").unwrap())
     }
     //
     #[test]

--- a/demo/src/io_helper.rs
+++ b/demo/src/io_helper.rs
@@ -182,6 +182,25 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn generic_process_input() -> anyhow::Result<()> {
+        let mut mock_reader = MockIoReader::new("read");
+        let mut mock_writer = MockIoWriter::new();
+
+        let test_str: String = process_input!(|| { 
+            writeln!(mock_writer, "write")?;
+            assert_eq!(mock_writer.buffer, "write\n".as_bytes());
+            assert_eq!(mock_writer.mock_output, "".to_string());
+            mock_writer.flush()?;
+            assert_eq!(mock_writer.buffer, "".as_bytes());
+            assert_eq!(mock_writer.mock_output, "write\n".to_string());
+        }, mock_reader);
+        dbg!(mock_reader);
+        dbg!(mock_writer);
+        dbg!(test_str);
+        Ok(())
+    }
+
     // EncodingError tests
     #[test]
     fn ciphertext() -> anyhow::Result<()> {

--- a/demo/src/io_helper.rs
+++ b/demo/src/io_helper.rs
@@ -87,33 +87,27 @@ mod tests {
     #[test]
     fn assent() {
         let mut mock_reader = MockIoReader::new("y");
-        let command: ConsentMenu = process_input(
-            || {
-                println! {"test"}
-            },
-            &mut mock_reader,
-        )
-        .unwrap();
+        let command: ConsentMenu = process_input(|| {}, &mut mock_reader).unwrap();
         assert_eq!(command, ConsentMenu::YesKE)
     }
 
-    // #[test]
-    // fn dissent() {
-    //     let input: &[u8] = b"n";
-    //     let command: ConsentMenu = process_input(|| {}, input).unwrap();
-    //     assert_eq!(command, ConsentMenu::NoKE)
-    // }
+    #[test]
+    fn dissent() {
+        let mut mock_reader = MockIoReader::new("n");
+        let command: ConsentMenu = process_input(|| {}, &mut mock_reader).unwrap();
+        assert_eq!(command, ConsentMenu::NoKE)
+    }
 
-    // #[test]
-    // fn consent_error() {
-    //     let input: &[u8] = b"N";
-    //     let error: anyhow::Error =
-    //         process_input::<ConsentMenu, CommandError, _, &[u8]>(|| {},
-    // input).unwrap_err();
+    #[test]
+    fn consent_error() {
+        let mut mock_reader = MockIoReader::new("N");
+        let error: Result<ConsentMenu, ProcessInputError> = process_input(|| {}, &mut mock_reader);
 
-    //     assert_eq!(
-    //         *error.downcast_ref::<CommandError>().unwrap(),
-    //         CommandError("N".to_string())
-    //     )
-    // }
+        assert!(error.is_err());
+
+        assert!(match error.unwrap_err() {
+            ProcessInputError::CommandParseError(e) => e == *"N",
+            _ => false,
+        });
+    }
 }

--- a/demo/src/io_helper.rs
+++ b/demo/src/io_helper.rs
@@ -34,7 +34,8 @@ pub enum ProcessInputError {
 /// type `T` as specified by caller. If successful, returns conversion.
 /// Otherwise, returns a custom error that contains information about the
 /// underlying error cause.
-// Notes: This is generic over the reader in order to decouple the program from stdin and allow for easier testing.
+// Notes: This is generic over the reader in order to decouple the program from
+// stdin and allow for easier testing.
 pub fn process_input<T, E, R>(reader: &mut R) -> Result<T, ProcessInputError>
 where
     T: FromStr<Err = E>,

--- a/demo/src/io_helper.rs
+++ b/demo/src/io_helper.rs
@@ -2,14 +2,12 @@
 // Note how we test the CLI:
 // - First we divide the crate into a library and a binary
 // - Then we can test the library! This is a little tricky because we need to
-//   abstract over types that implement the [`std::io::BufRead`] trait in order
-//   to test read behavior.
+//   abstract over types that implement [`std::io::BufRead`] in order to test
+//   read behavior and types that implement [`std::io::Write`] to test write
+//   behavior.
 //
 // This makes the code more complex and less understandable, so there is a
-// testing tradeoff here. If we also want to test stdout behavior, we would have
-// to remove any println! functionality in the code base and abstract over a
-// generic that implements the [`std::io::Write`] method TODO: Test stdout
-// behavior
+// tradeoff here between readability and testability. 
 
 use anyhow::Result;
 use classical_crypto::errors::EncodingError;

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -18,32 +18,32 @@ use crate::menu::{DecryptMenu, MainMenu, Menu};
 /// - Decrypt a message;
 /// - Quit the CLI application.
 pub fn menu() -> Result<()> {
-   loop {
+    loop {
         {
-        let mut reader = BufReader::new(std::io::stdin());
+            let mut reader = BufReader::new(std::io::stdin());
 
-        // Get menu selection from user
-        let command = process_input(MainMenu::print_menu, &mut reader);
-        
-        match command {
-            // Process menu selection from user
+            // Get menu selection from user
+            let command = process_input(MainMenu::print_menu, &mut reader);
 
-            // Generate a key
-            Ok(MainMenu::GenKE) => make_key()?,
-            // Encrypt a message
-            Ok(MainMenu::EncryptKE) => encrypt()?,
-            // Attempt to decrypt a ciphertext
-            Ok(MainMenu::DecryptKE) => {
-                // Print decryption menu and get user selection
-                let command = decryption_menu()?;
-                // Proceed with decryption as specified by user
-                decrypt(command)?;
-            }
-            // Quit the CLI application
-            Ok(MainMenu::QuitKE) => break Ok(()),
-            Err(_) => continue,
-        };
-    }
+            match command {
+                // Process menu selection from user
+
+                // Generate a key
+                Ok(MainMenu::GenKE) => make_key()?,
+                // Encrypt a message
+                Ok(MainMenu::EncryptKE) => encrypt()?,
+                // Attempt to decrypt a ciphertext
+                Ok(MainMenu::DecryptKE) => {
+                    // Print decryption menu and get user selection
+                    let command = decryption_menu()?;
+                    // Proceed with decryption as specified by user
+                    decrypt(command)?;
+                }
+                // Quit the CLI application
+                Ok(MainMenu::QuitKE) => break Ok(()),
+                Err(_) => continue,
+            };
+        }
     }
 }
 

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -62,7 +62,7 @@ pub fn decryption_menu(mut reader: impl BufRead, mut writer: impl Write) -> Resu
     writeln!(writer,
     "If not, don't despair. Just guess! On average, you can expect success using this \nsimple brute force attack method after trying 13 keys chosen uniformly at random."
     )?;
-
+    
     let command: DecryptMenu =
         process_input(|| DecryptMenu::print_menu(writer.by_ref()), &mut reader)?;
     Ok(command)

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -1,7 +1,4 @@
 //! The demo libary crate, containing functionality supporting the demo CLI.
-// TODO: handle errors properly instead of allowing panicking (partially
-// completed, but many suboptions from main menu will still panic if user inputs
-// something invalid)
 use anyhow::Result;
 use std::io::{BufRead, Write};
 

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -1,7 +1,9 @@
 //! The demo libary crate, containing functionality supporting the demo CLI.
-// TODO: handle errors properly instead of allowing panicking (partially completed, but many suboptions from main menu will still panic if user inputs something invalid)
+// TODO: handle errors properly instead of allowing panicking (partially
+// completed, but many suboptions from main menu will still panic if user inputs
+// something invalid)
 use anyhow::Result;
-use std::io::BufReader;
+use std::io::{BufRead, BufReader};
 
 pub mod crypto_functionality;
 mod io_helper;
@@ -30,15 +32,15 @@ pub fn menu() -> Result<()> {
                 // Process menu selection from user
 
                 // Generate a key
-                Ok(MainMenu::GenKE) => make_key()?,
+                Ok(MainMenu::GenKE) => make_key(&mut reader)?,
                 // Encrypt a message
-                Ok(MainMenu::EncryptKE) => encrypt()?,
+                Ok(MainMenu::EncryptKE) => encrypt(&mut reader)?,
                 // Attempt to decrypt a ciphertext
                 Ok(MainMenu::DecryptKE) => {
                     // Print decryption menu and get user selection
-                    let command = decryption_menu()?;
+                    let command = decryption_menu(&mut reader)?;
                     // Proceed with decryption as specified by user
-                    decrypt(command)?;
+                    decrypt(command, &mut reader)?;
                 }
                 // Quit the CLI application
                 Ok(MainMenu::QuitKE) => break Ok(()),
@@ -55,7 +57,7 @@ pub fn menu() -> Result<()> {
 /// - Decrypt using a known key;
 /// - Computer-aided brute force attack;
 /// - Quit decryption menu.
-pub fn decryption_menu() -> Result<DecryptMenu> {
+pub fn decryption_menu(mut reader: impl BufRead) -> Result<DecryptMenu> {
     println!("\nGreat, let's work on decrypting your ciphertext.");
     println!(
         "If you know what key was used to encrypt this message, this should only take one try."
@@ -63,8 +65,6 @@ pub fn decryption_menu() -> Result<DecryptMenu> {
     println!(
     "If not, don't despair. Just guess! On average, you can expect success using this \nsimple brute force attack method after trying 13 keys chosen uniformly at random."
     );
-
-    let mut reader = BufReader::new(std::io::stdin());
 
     let command: DecryptMenu = process_input(DecryptMenu::print_menu, &mut reader)?;
     Ok(command)

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -1,4 +1,5 @@
 //! The demo libary crate, containing functionality supporting the demo CLI.
+// TODO: handle errors properly instead of allowing panicking (partially completed, but many suboptions from main menu will still panic if user inputs something invalid)
 use anyhow::Result;
 use std::io::BufReader;
 

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -1,6 +1,6 @@
 //! The demo libary crate, containing functionality supporting the demo CLI.
 use anyhow::Result;
-use std::io::{stdin, BufReader};
+use std::io::BufReader;
 
 pub mod crypto_functionality;
 mod io_helper;

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -1,6 +1,6 @@
 //! The demo libary crate, containing functionality supporting the demo CLI.
-use std::io::stdin;
 use anyhow::Result;
+use std::io::stdin;
 
 pub mod crypto_functionality;
 mod io_helper;

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -62,7 +62,6 @@ pub fn decryption_menu(mut reader: impl BufRead, mut writer: impl Write) -> Resu
     writeln!(writer,
     "If not, don't despair. Just guess! On average, you can expect success using this \nsimple brute force attack method after trying 13 keys chosen uniformly at random."
     )?;
-    writer.flush()?;
 
     let command: DecryptMenu =
         process_input(|| DecryptMenu::print_menu(writer.by_ref()), &mut reader)?;

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -67,6 +67,18 @@ pub fn decryption_menu(mut reader: impl BufRead, mut writer: impl Write) -> Resu
     DecryptMenu::print_menu(writer.by_ref())?;
 
     // Get response from user
-    let command: DecryptMenu = process_input(&mut reader)?;
-    Ok(command)
+    let command = loop {
+        let command = process_input(&mut reader);
+
+        match command {
+            Ok(DecryptMenu::Bruteforce) | Ok(DecryptMenu::KnownKey) | Ok(DecryptMenu::Quit) => {
+                break command
+            }
+            Err(e) => {
+                writeln!(writer, "Error! {}", e)?;
+                continue;
+            }
+        };
+    };
+    Ok(command?)
 }

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -1,4 +1,5 @@
 //! The demo libary crate, containing functionality supporting the demo CLI.
+use std::io::stdin;
 use anyhow::Result;
 
 pub mod crypto_functionality;
@@ -19,7 +20,7 @@ use crate::menu::{DecryptMenu, MainMenu, Menu};
 pub fn menu() -> Result<()> {
     loop {
         // Get menu selection from user
-        let command: MainMenu = process_input(MainMenu::print_menu)?;
+        let command: MainMenu = process_input(MainMenu::print_menu, &mut std::io::stdin().lock())?;
 
         // Process menu selection from user
         match command {
@@ -56,6 +57,6 @@ pub fn decryption_menu() -> Result<DecryptMenu> {
     "If not, don't despair. Just guess! On average, you can expect success using this \nsimple brute force attack method after trying 13 keys chosen uniformly at random."
     );
 
-    let command: DecryptMenu = process_input(DecryptMenu::print_menu)?;
+    let command: DecryptMenu = process_input(DecryptMenu::print_menu, stdin().lock())?;
     Ok(command)
 }

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -22,29 +22,27 @@ use crate::menu::{DecryptMenu, MainMenu, Menu};
 /// - Quit the CLI application.
 pub fn menu(mut reader: impl BufRead, mut writer: impl Write) -> Result<()> {
     loop {
-        {
-            // Get menu selection from user
-            let command = process_input(|| MainMenu::print_menu(writer.by_ref()), &mut reader);
+        // Get menu selection from user
+        let command = process_input(|| MainMenu::print_menu(writer.by_ref()), &mut reader);
 
-            match command {
-                // Process menu selection from user
+        match command {
+            // Process menu selection from user
 
-                // Generate a key
-                Ok(MainMenu::GenKE) => make_key(&mut reader, writer.by_ref())?,
-                // Encrypt a message
-                Ok(MainMenu::EncryptKE) => encrypt(&mut reader, writer.by_ref())?,
-                // Attempt to decrypt a ciphertext
-                Ok(MainMenu::DecryptKE) => {
-                    // Print decryption menu and get user selection
-                    let command = decryption_menu(&mut reader, writer.by_ref())?;
-                    // Proceed with decryption as specified by user
-                    decrypt(command, &mut reader, writer.by_ref())?;
-                }
-                // Quit the CLI application
-                Ok(MainMenu::QuitKE) => break Ok(()),
-                Err(_) => continue,
-            };
-        }
+            // Generate a key
+            Ok(MainMenu::GenKE) => make_key(&mut reader, writer.by_ref())?,
+            // Encrypt a message
+            Ok(MainMenu::EncryptKE) => encrypt(&mut reader, writer.by_ref())?,
+            // Attempt to decrypt a ciphertext
+            Ok(MainMenu::DecryptKE) => {
+                // Print decryption menu and get user selection
+                let command = decryption_menu(&mut reader, writer.by_ref())?;
+                // Proceed with decryption as specified by user
+                decrypt(command, &mut reader, writer.by_ref())?;
+            }
+            // Quit the CLI application
+            Ok(MainMenu::QuitKE) => break Ok(()),
+            Err(_) => continue,
+        };
     }
 }
 
@@ -56,13 +54,15 @@ pub fn menu(mut reader: impl BufRead, mut writer: impl Write) -> Result<()> {
 /// - Computer-aided brute force attack;
 /// - Quit decryption menu.
 pub fn decryption_menu(mut reader: impl BufRead, mut writer: impl Write) -> Result<DecryptMenu> {
-    println!("\nGreat, let's work on decrypting your ciphertext.");
-    println!(
+    writeln!(writer, "\nGreat, let's work on decrypting your ciphertext.")?;
+    writeln!(
+        writer,
         "If you know what key was used to encrypt this message, this should only take one try."
-    );
-    println!(
+    )?;
+    writeln!(writer,
     "If not, don't despair. Just guess! On average, you can expect success using this \nsimple brute force attack method after trying 13 keys chosen uniformly at random."
-    );
+    )?;
+    writer.flush()?;
 
     let command: DecryptMenu =
         process_input(|| DecryptMenu::print_menu(writer.by_ref()), &mut reader)?;

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -22,8 +22,11 @@ use crate::menu::{DecryptMenu, MainMenu, Menu};
 /// - Quit the CLI application.
 pub fn menu(mut reader: impl BufRead, mut writer: impl Write) -> Result<()> {
     loop {
+        // Print main menu
+        MainMenu::print_menu(writer.by_ref())?;
+
         // Get menu selection from user
-        let command = process_input(|| MainMenu::print_menu(writer.by_ref()), &mut reader);
+        let command = process_input(&mut reader);
 
         match command {
             // Process menu selection from user
@@ -62,8 +65,11 @@ pub fn decryption_menu(mut reader: impl BufRead, mut writer: impl Write) -> Resu
     writeln!(writer,
     "If not, don't despair. Just guess! On average, you can expect success using this \nsimple brute force attack method after trying 13 keys chosen uniformly at random."
     )?;
-    
-    let command: DecryptMenu =
-        process_input(|| DecryptMenu::print_menu(writer.by_ref()), &mut reader)?;
+
+    // Print decryption menu options
+    DecryptMenu::print_menu(writer.by_ref())?;
+
+    // Get response from user
+    let command: DecryptMenu = process_input(&mut reader)?;
     Ok(command)
 }

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -1,6 +1,6 @@
 //! The demo libary crate, containing functionality supporting the demo CLI.
 use anyhow::Result;
-use std::io::stdin;
+use std::io::{stdin, BufReader};
 
 pub mod crypto_functionality;
 mod io_helper;
@@ -18,26 +18,32 @@ use crate::menu::{DecryptMenu, MainMenu, Menu};
 /// - Decrypt a message;
 /// - Quit the CLI application.
 pub fn menu() -> Result<()> {
-    loop {
-        // Get menu selection from user
-        let command: MainMenu = process_input(MainMenu::print_menu, &mut std::io::stdin().lock())?;
+   loop {
+        {
+        let mut reader = BufReader::new(std::io::stdin());
 
-        // Process menu selection from user
+        // Get menu selection from user
+        let command = process_input(MainMenu::print_menu, &mut reader);
+        
         match command {
+            // Process menu selection from user
+
             // Generate a key
-            MainMenu::GenKE => make_key()?,
+            Ok(MainMenu::GenKE) => make_key()?,
             // Encrypt a message
-            MainMenu::EncryptKE => encrypt()?,
+            Ok(MainMenu::EncryptKE) => encrypt()?,
             // Attempt to decrypt a ciphertext
-            MainMenu::DecryptKE => {
+            Ok(MainMenu::DecryptKE) => {
                 // Print decryption menu and get user selection
                 let command = decryption_menu()?;
                 // Proceed with decryption as specified by user
                 decrypt(command)?;
             }
             // Quit the CLI application
-            MainMenu::QuitKE => break Ok(()),
+            Ok(MainMenu::QuitKE) => break Ok(()),
+            Err(_) => continue,
         };
+    }
     }
 }
 
@@ -57,6 +63,8 @@ pub fn decryption_menu() -> Result<DecryptMenu> {
     "If not, don't despair. Just guess! On average, you can expect success using this \nsimple brute force attack method after trying 13 keys chosen uniformly at random."
     );
 
-    let command: DecryptMenu = process_input(DecryptMenu::print_menu, stdin().lock())?;
+    let mut reader = BufReader::new(std::io::stdin());
+
+    let command: DecryptMenu = process_input(DecryptMenu::print_menu, &mut reader)?;
     Ok(command)
 }

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -2,11 +2,15 @@
 //! allows key generation, message encryption, and ciphertext decryption
 //! (including a computer-aided brute force attack) using the Latin Shift
 //! Cipher.
+use std::io::{BufReader, BufWriter};
+
 use anyhow::Result;
 use demo::menu;
 
 fn main() -> Result<()> {
     println!("\nWelcome to the Latin Shift Cipher Demo!");
-    menu()?;
+    let reader = BufReader::new(std::io::stdin());
+    let writer = BufWriter::new(std::io::stdout());
+    menu(reader, writer)?;
     Ok(())
 }

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -2,7 +2,7 @@
 //! allows key generation, message encryption, and ciphertext decryption
 //! (including a computer-aided brute force attack) using the Latin Shift
 //! Cipher.
-use std::io::{BufReader, BufWriter};
+use std::io::BufReader;
 
 use anyhow::Result;
 use demo::menu;
@@ -12,9 +12,9 @@ fn main() -> Result<()> {
 
     // The demo library crate is decoupled from stdin and stdout through the use of
     // dependency injection
-    let reader = BufReader::new(std::io::stdin());
-    let writer = BufWriter::new(std::io::stdout());
+    let mut reader = BufReader::new(std::io::stdin());
+    let mut writer = std::io::stdout();
 
-    menu(reader, writer)?;
+    menu(&mut reader, &mut writer)?;
     Ok(())
 }

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -7,5 +7,6 @@ use demo::menu;
 
 fn main() -> Result<()> {
     println!("\nWelcome to the Latin Shift Cipher Demo!");
-    menu().inspect_err(|e| eprintln!("Application error: {e}"))
+    menu()?;
+    Ok(())
 }

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -9,8 +9,12 @@ use demo::menu;
 
 fn main() -> Result<()> {
     println!("\nWelcome to the Latin Shift Cipher Demo!");
+
+    // The demo library crate is decoupled from stdin and stdout through the use of
+    // dependency injection
     let reader = BufReader::new(std::io::stdin());
     let writer = BufWriter::new(std::io::stdout());
+
     menu(reader, writer)?;
     Ok(())
 }

--- a/demo/src/menu.rs
+++ b/demo/src/menu.rs
@@ -1,4 +1,5 @@
 //! Menus.
+use crate::io_helper::ProcessInputError;
 use std::str::FromStr;
 use thiserror::Error;
 
@@ -69,7 +70,7 @@ impl MainMenu {
 }
 
 impl FromStr for MainMenu {
-    type Err = CommandError;
+    type Err = ProcessInputError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
@@ -77,7 +78,7 @@ impl FromStr for MainMenu {
             MainMenu::ENCRYPT_KE => Ok(MainMenu::EncryptKE),
             MainMenu::DECRYPT_KE => Ok(MainMenu::DecryptKE),
             MainMenu::QUIT_KE => Ok(MainMenu::QuitKE),
-            _ => Err(CommandError(s.to_string())),
+            _ => Err(ProcessInputError::CommandParseError(s.to_string())),
         }
     }
 }
@@ -112,13 +113,13 @@ impl ConsentMenu {
 }
 
 impl FromStr for ConsentMenu {
-    type Err = CommandError;
+    type Err = ProcessInputError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             ConsentMenu::YES_KE => Ok(ConsentMenu::YesKE),
             ConsentMenu::NO_KE => Ok(ConsentMenu::NoKE),
-            _ => Err(CommandError(s.to_string())),
+            _ => Err(ProcessInputError::CommandParseError(s.to_string())),
         }
     }
 }
@@ -164,14 +165,14 @@ impl DecryptMenu {
 }
 
 impl FromStr for DecryptMenu {
-    type Err = CommandError;
+    type Err = ProcessInputError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             DecryptMenu::KNOWN_KEY_KE => Ok(DecryptMenu::KnownKey),
             DecryptMenu::BRUTE_FORCE_KE => Ok(DecryptMenu::Bruteforce),
             DecryptMenu::QUIT_KE => Ok(DecryptMenu::Quit),
-            _ => Err(CommandError(s.to_string())),
+            _ => Err(ProcessInputError::CommandParseError(s.to_string())),
         }
     }
 }
@@ -182,8 +183,3 @@ pub struct Command<'a> {
     key: &'a str,
     menu_msg: &'a str,
 }
-
-/// The error returned upon failure to parse a [`Command`] from a string.
-#[derive(Error, Debug, PartialEq)]
-#[error("Invalid command: {0}")]
-pub struct CommandError(pub String);

--- a/demo/src/menu.rs
+++ b/demo/src/menu.rs
@@ -18,6 +18,7 @@ pub trait Menu<const N: usize> {
 pub struct MenuArray<const N: usize>([Command<'static>; N]);
 
 /// Represents the program's main menu options.
+#[derive(Debug, PartialEq)]
 pub enum MainMenu {
     /// User wants to generate a key.
     GenKE,
@@ -124,6 +125,7 @@ impl FromStr for ConsentMenu {
 }
 
 /// Represents the decryption menu.
+#[derive(Debug, PartialEq)]
 pub enum DecryptMenu {
     /// User knows the key.
     KnownKey,

--- a/demo/src/menu.rs
+++ b/demo/src/menu.rs
@@ -184,6 +184,6 @@ pub struct Command<'a> {
 }
 
 /// The error returned upon failure to parse a [`Command`] from a string.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 #[error("Invalid command: {0}")]
-pub struct CommandError(String);
+pub struct CommandError(pub String);

--- a/demo/src/menu.rs
+++ b/demo/src/menu.rs
@@ -11,6 +11,7 @@ pub trait Menu<const N: usize>: FromStr {
         for item in Self::menu_array().0 {
             writeln!(writer, "{}: {}", item.key, item.menu_msg)?
         }
+        writer.flush()?;
         Ok(())
     }
 }

--- a/demo/src/menu.rs
+++ b/demo/src/menu.rs
@@ -8,8 +8,9 @@ pub trait Menu<const N: usize>: FromStr {
 
     fn print_menu(mut writer: impl Write) -> std::io::Result<()> {
         writeln!(writer, "\nPlease enter one of the following options:")?;
+
         for item in Self::menu_array().0 {
-            writeln!(writer, "{}: {}", item.key, item.menu_msg)?
+            writeln!(writer, "{}: {}", item.key, item.menu_msg)?;
         }
 
         Ok(())

--- a/demo/src/menu.rs
+++ b/demo/src/menu.rs
@@ -3,7 +3,7 @@ use crate::io_helper::ProcessInputError;
 use std::str::FromStr;
 
 /// Represents menu functionality.
-pub trait Menu<const N: usize> {
+pub trait Menu<const N: usize>: FromStr {
     fn menu_array() -> MenuArray<N>;
 
     fn print_menu() {

--- a/demo/src/menu.rs
+++ b/demo/src/menu.rs
@@ -11,7 +11,7 @@ pub trait Menu<const N: usize>: FromStr {
         for item in Self::menu_array().0 {
             writeln!(writer, "{}: {}", item.key, item.menu_msg)?
         }
-        writer.flush()?;
+
         Ok(())
     }
 }

--- a/demo/src/menu.rs
+++ b/demo/src/menu.rs
@@ -1,7 +1,6 @@
 //! Menus.
 use crate::io_helper::ProcessInputError;
 use std::str::FromStr;
-use thiserror::Error;
 
 /// Represents menu functionality.
 pub trait Menu<const N: usize> {

--- a/demo/src/menu.rs
+++ b/demo/src/menu.rs
@@ -1,16 +1,17 @@
 //! Menus.
 use crate::io_helper::ProcessInputError;
-use std::str::FromStr;
+use std::{io::Write, str::FromStr};
 
 /// Represents menu functionality.
 pub trait Menu<const N: usize>: FromStr {
     fn menu_array() -> MenuArray<N>;
 
-    fn print_menu() {
-        println!("\nPlease enter one of the following options:");
+    fn print_menu(mut writer: impl Write) -> std::io::Result<()> {
+        writeln!(writer, "\nPlease enter one of the following options:")?;
         for item in Self::menu_array().0 {
-            println!("{}: {}", item.key, item.menu_msg)
+            writeln!(writer, "{}: {}", item.key, item.menu_msg)?
         }
+        Ok(())
     }
 }
 

--- a/demo/src/menu.rs
+++ b/demo/src/menu.rs
@@ -82,6 +82,7 @@ impl FromStr for MainMenu {
     }
 }
 
+#[derive(Debug, PartialEq)]
 /// Represents user assent or dissent.
 pub enum ConsentMenu {
     /// User assents.


### PR DESCRIPTION
This PR:
- decouples the program from stdin/stdout for easier testing.
- handles clippy warnings introduced by rust updates
- adds comments throughout
- simplifies code wherever an opportunity was spotted, i.e., simplifies a match statement with the use of a match guard
- removes unimplemented types for encryption/decryption errors
- revises the helper function for processing input from the user:
    - no longer loops until the user provides correct input and instead propagates the error to the caller
    -  removes the generic parameter `F: FnMut` that had been used to print instructions to the user within process input; these instructions are now given to the user outside of `process_input`.
    - introduces a custom enum to represent a resulting error, which converts automatically from the underlying error, if any